### PR TITLE
Prettier Ignore Comment Removal

### DIFF
--- a/webapps/frontend/ui/monitoring/plugins/base/app/views/processDefinition/calledProcessDefinitionTable.js
+++ b/webapps/frontend/ui/monitoring/plugins/base/app/views/processDefinition/calledProcessDefinitionTable.js
@@ -49,12 +49,26 @@ module.exports = [
             var filter;
             var processData = $scope.processData.newChild($scope);
 
-            // prettier-ignore
             $scope.headColumns = [
-            { class: 'process-definition', request: 'label', sortable: true, content: $translate.instant('PLUGIN_CALLED_PROCESS')},
-            { class: 'called-process-state', request: 'state', sortable: true, content: $translate.instant('PLUGIN_CALLED_PROCESS_STATE')},
-            { class: 'activity', request: '[0].name', sortable: true, content: $translate.instant('PLUGIN_ACTIVITY')}
-        ];
+              {
+                class: 'process-definition',
+                request: 'label',
+                sortable: true,
+                content: $translate.instant('PLUGIN_CALLED_PROCESS')
+              },
+              {
+                class: 'called-process-state',
+                request: 'state',
+                sortable: true,
+                content: $translate.instant('PLUGIN_CALLED_PROCESS_STATE')
+              },
+              {
+                class: 'activity',
+                request: '[0].name',
+                sortable: true,
+                content: $translate.instant('PLUGIN_ACTIVITY')
+              }
+            ];
 
             // Default sorting
             $scope.sortObj = loadLocal({

--- a/webapps/frontend/ui/monitoring/plugins/base/app/views/processDefinition/processInstanceTable.js
+++ b/webapps/frontend/ui/monitoring/plugins/base/app/views/processDefinition/processInstanceTable.js
@@ -56,13 +56,36 @@ module.exports = [
             $scope.onSearchChange = updateView;
             $scope.onSortChange = updateView;
 
-            // prettier-ignore
             $scope.headColumns = [
-          { class: 'state',        request: 'state',       sortable: false, content: $translate.instant('PLUGIN_PROCESS_INSTANCE_STATE')},
-          { class: 'instance-id',  request: 'instanceId',  sortable: false, content: $translate.instant('PLUGIN_PROCESS_INSTANCE_ID')},
-          { class: 'start-time',   request: 'startTime',   sortable: true,  content: $translate.instant('PLUGIN_PROCESS_INSTANCE_START_TIME')},
-          { class: 'business-key', request: 'businessKey', sortable: false, content: $translate.instant('PLUGIN_PROCESS_INSTANCE_BUSINESS_KEY')}
-        ];
+              {
+                class: 'state',
+                request: 'state',
+                sortable: false,
+                content: $translate.instant('PLUGIN_PROCESS_INSTANCE_STATE')
+              },
+              {
+                class: 'instance-id',
+                request: 'instanceId',
+                sortable: false,
+                content: $translate.instant('PLUGIN_PROCESS_INSTANCE_ID')
+              },
+              {
+                class: 'start-time',
+                request: 'startTime',
+                sortable: true,
+                content: $translate.instant(
+                  'PLUGIN_PROCESS_INSTANCE_START_TIME'
+                )
+              },
+              {
+                class: 'business-key',
+                request: 'businessKey',
+                sortable: false,
+                content: $translate.instant(
+                  'PLUGIN_PROCESS_INSTANCE_BUSINESS_KEY'
+                )
+              }
+            ];
 
             // Default sorting
             var defaultValue = {sortBy: 'startTime', sortOrder: 'desc'};


### PR DESCRIPTION
## Summary
This PR removes the `prettier-ignore` comment from two frontend files, and formats them, to stop prettier preventing a succesful build of the platform.
## Relevant Issue
[#123 ](https://github.com/finos/fluxnova-bpm-platform/issues/123)