### PR TITLE
feat(engine-rest): add deprecated camundaFormRef for backward compatibility

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/finos/fluxnova/bpm/engine/rest/dto/CamundaFormRef.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/finos/fluxnova/bpm/engine/rest/dto/CamundaFormRef.ftl
@@ -1,0 +1,22 @@
+<#macro dto_macro docsUrl="">
+<@lib.dto>
+
+    <@lib.property
+        name = "key"
+        type = "string"
+        desc = "The key of the Camunda Form." />
+
+    <@lib.property
+        name = "binding"
+        type = "string"
+        desc = "The binding of the Camunda Form. Can be `latest`, `deployment` or `version`." />
+
+    <@lib.property
+        name = "version"
+        type = "integer"
+        format = "int32"
+        last = true
+        desc = "The specific version of a Camunda Form. This property is only set if `binding` is `version`." />
+
+</@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/finos/fluxnova/bpm/engine/rest/dto/FormDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/finos/fluxnova/bpm/engine/rest/dto/FormDto.ftl
@@ -16,6 +16,13 @@
         desc = "A reference to a specific version of a Fluxnova Form." />
 
     <@lib.property
+        name = "camundaFormRef"
+        type = "ref"
+        dto = "CamundaFormRef"
+        deprecated = true
+        desc = "**Deprecated.** Use `fluxnovaFormRef` instead. A reference to a specific version of a Camunda Form." />
+
+    <@lib.property
         name = "contextPath"
         type = "string"
         last = true

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/finos/fluxnova/bpm/engine/rest/dto/runtime/task/TaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/finos/fluxnova/bpm/engine/rest/dto/runtime/task/TaskDto.ftl
@@ -127,6 +127,13 @@
         desc = "A reference to a specific version of a Fluxnova Form."/>
 
     <@lib.property
+        name = "camundaFormRef"
+        type = "ref"
+        dto = "CamundaFormRef"
+        deprecated = true
+        desc = "**Deprecated.** Use `fluxnovaFormRef` instead. A reference to a specific version of a Camunda Form."/>
+
+    <@lib.property
         name = "tenantId"
         type = "string"
         desc = "If not `null`, the tenant id of the task." />

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/get.ftl
@@ -68,6 +68,11 @@
                              "binding": "version",
                              "version": 2
                            },
+                           "camundaFormRef":{
+                             "key": "aCamundaFormKey",
+                             "binding": "version",
+                             "version": 2
+                           },
                            "tenantId": "aTenantId",
                            "taskState": "aTaskState"
                          }
@@ -101,6 +106,11 @@
                            "formKey":"aFormKey",
                            "fluxnovaFormRef":{
                              "key": "aFluxnovaFormKey",
+                             "binding": "version",
+                             "version": 2
+                           },
+                           "camundaFormRef":{
+                             "key": "aCamundaFormKey",
                              "binding": "version",
                              "version": 2
                            },
@@ -139,6 +149,11 @@
                            "formKey":"aFormKey",
                            "fluxnovaFormRef":{
                              "key": "aFluxnovaFormKey",
+                             "binding": "version",
+                             "version": 2
+                           },
+                           "camundaFormRef":{
+                             "key": "aCamundaFormKey",
                              "binding": "version",
                              "version": 2
                            },
@@ -187,6 +202,11 @@
                            "taskDefinitionKey":"aTaskDefinitionKey",
                            "suspended": false,
                            "formKey":"aFormKey",
+                           "fluxnovaFormRef":{
+                             "key": "aCamundaFormKey",
+                             "binding": "version",
+                             "version": 2
+                           },
                            "camundaFormRef":{
                              "key": "aCamundaFormKey",
                              "binding": "version",

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/post.ftl
@@ -158,6 +158,11 @@
                              "binding": "version",
                              "version": 2
                            },
+                           "camundaFormRef":{
+                             "key": "aCamundaFormKey",
+                             "binding": "version",
+                             "version": 2
+                           },
                            "tenantId":"aTenantId",
                            "taskState": "aTaskState"
                          }

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/get.ftl
@@ -53,6 +53,11 @@
                            "binding": "version",
                            "version": 2
                          },
+                         "camundaFormRef":{
+                           "key": "aCamundaFormKey",
+                           "binding": "version",
+                           "version": 2
+                         },
                          "tenantId":"aTenantId",
 			 "taskState": "aTaskState"
                        }

--- a/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/dto/task/FormDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/dto/task/FormDto.java
@@ -16,8 +16,10 @@
  */
 package org.finos.fluxnova.bpm.engine.rest.dto.task;
 
+import org.finos.fluxnova.bpm.engine.form.CamundaFormRef;
 import org.finos.fluxnova.bpm.engine.form.FluxnovaFormRef;
 import org.finos.fluxnova.bpm.engine.form.FormData;
+import org.finos.fluxnova.bpm.engine.impl.form.CamundaFormRefImpl;
 
 /**
  *
@@ -27,6 +29,9 @@ public class FormDto {
 
   private String key;
   private FluxnovaFormRef fluxnovaFormRef;
+  /** @deprecated Use {@link #fluxnovaFormRef} instead. */
+  @Deprecated
+  private CamundaFormRef camundaFormRef;
   private String contextPath;
 
   public void setKey(String form) {
@@ -43,6 +48,13 @@ public class FormDto {
 
   public void setFluxnovaFormRef(FluxnovaFormRef fluxnovaFormRef) {
     this.fluxnovaFormRef = fluxnovaFormRef;
+    this.camundaFormRef = toCamundaFormRef(fluxnovaFormRef);
+  }
+
+  /** @deprecated Use {@link #getCamundaFormRef()} instead. */
+  @Deprecated
+  public CamundaFormRef getCamundaFormRef() {
+    return camundaFormRef;
   }
 
   public void setContextPath(String contextPath) {
@@ -59,8 +71,18 @@ public class FormDto {
     if (formData != null) {
       dto.key = formData.getFormKey();
       dto.fluxnovaFormRef = formData.getFluxnovaFormRef();
+      dto.camundaFormRef = toCamundaFormRef(formData.getFluxnovaFormRef());
     }
 
     return dto;
+  }
+
+  private static CamundaFormRef toCamundaFormRef(FluxnovaFormRef ref) {
+    if (ref == null) {
+      return null;
+    }
+    CamundaFormRefImpl camundaFormRef = new CamundaFormRefImpl(ref.getKey(), ref.getBinding());
+    camundaFormRef.setVersion(ref.getVersion());
+    return camundaFormRef;
   }
 }

--- a/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/dto/task/TaskDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/dto/task/TaskDto.java
@@ -19,7 +19,9 @@ package org.finos.fluxnova.bpm.engine.rest.dto.task;
 import java.util.Date;
 
 import org.finos.fluxnova.bpm.engine.BadUserRequestException;
+import org.finos.fluxnova.bpm.engine.form.CamundaFormRef;
 import org.finos.fluxnova.bpm.engine.form.FluxnovaFormRef;
+import org.finos.fluxnova.bpm.engine.impl.form.CamundaFormRefImpl;
 import org.finos.fluxnova.bpm.engine.rest.dto.converter.DelegationStateConverter;
 import org.finos.fluxnova.bpm.engine.task.DelegationState;
 import org.finos.fluxnova.bpm.engine.task.Task;
@@ -48,6 +50,9 @@ public class TaskDto {
   private boolean suspended;
   private String formKey;
   private FluxnovaFormRef fluxnovaFormRef;
+  /** @deprecated Use {@link #fluxnovaFormRef} instead. */
+  @Deprecated
+  private CamundaFormRef camundaFormRef;
   private String tenantId;
   /**
    * Returns task State of task
@@ -87,6 +92,7 @@ public class TaskDto {
     try {
       this.formKey = task.getFormKey();
       this.fluxnovaFormRef = task.getFluxnovaFormRef();
+      this.camundaFormRef = toCamundaFormRef(this.fluxnovaFormRef);
     }
     catch (BadUserRequestException e) {
       // ignore (initializeFormKeys was not called)
@@ -228,6 +234,12 @@ public class TaskDto {
     return fluxnovaFormRef;
   }
 
+  /** @deprecated Use {@link #getFluxnovaFormRef()} instead. */
+  @Deprecated
+  public CamundaFormRef getCamundaFormRef() {
+    return camundaFormRef;
+  }
+
   public String getTenantId() {
     return tenantId;
   }
@@ -275,11 +287,21 @@ public class TaskDto {
     try {
       dto.formKey = task.getFormKey();
       dto.fluxnovaFormRef = task.getFluxnovaFormRef();
+      dto.camundaFormRef = toCamundaFormRef(dto.fluxnovaFormRef);
     }
     catch (BadUserRequestException e) {
       // ignore (initializeFormKeys was not called)
     }
     return dto;
+  }
+
+  private static CamundaFormRef toCamundaFormRef(FluxnovaFormRef ref) {
+    if (ref == null) {
+      return null;
+    }
+    CamundaFormRefImpl camundaFormRef = new CamundaFormRefImpl(ref.getKey(), ref.getBinding());
+    camundaFormRef.setVersion(ref.getVersion());
+    return camundaFormRef;
   }
 
   public void updateTask(Task task) {

--- a/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/hal/task/HalTask.java
+++ b/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/hal/task/HalTask.java
@@ -22,7 +22,9 @@ import javax.ws.rs.core.UriBuilder;
 
 import org.finos.fluxnova.bpm.engine.BadUserRequestException;
 import org.finos.fluxnova.bpm.engine.ProcessEngine;
+import org.finos.fluxnova.bpm.engine.form.CamundaFormRef;
 import org.finos.fluxnova.bpm.engine.form.FluxnovaFormRef;
+import org.finos.fluxnova.bpm.engine.impl.form.CamundaFormRefImpl;
 import org.finos.fluxnova.bpm.engine.rest.CaseDefinitionRestService;
 import org.finos.fluxnova.bpm.engine.rest.CaseExecutionRestService;
 import org.finos.fluxnova.bpm.engine.rest.CaseInstanceRestService;
@@ -88,6 +90,9 @@ public class HalTask extends HalResource<HalTask> {
   private boolean suspended;
   private String formKey;
   private FluxnovaFormRef fluxnovaFormRef;
+  /** @deprecated Use {@link #fluxnovaFormRef} instead. */
+  @Deprecated
+  private CamundaFormRef camundaFormRef;
   private String tenantId;
 
   public static HalTask generate(Task task, ProcessEngine engine) {
@@ -126,6 +131,7 @@ public class HalTask extends HalResource<HalTask> {
     try {
       dto.formKey = task.getFormKey();
       dto.fluxnovaFormRef = task.getFluxnovaFormRef();
+      dto.camundaFormRef = toCamundaFormRef(dto.fluxnovaFormRef);
     }
     catch (BadUserRequestException e) {
       // ignore (initializeFormKeys was not called)
@@ -232,8 +238,23 @@ public class HalTask extends HalResource<HalTask> {
     return fluxnovaFormRef;
   }
 
+  /** @deprecated Use {@link #getFluxnovaFormRef()} instead. */
+  @Deprecated
+  public CamundaFormRef getCamundaFormRef() {
+    return camundaFormRef;
+  }
+
   public String getTenantId() {
     return tenantId;
+  }
+
+  private static CamundaFormRef toCamundaFormRef(FluxnovaFormRef ref) {
+    if (ref == null) {
+      return null;
+    }
+    CamundaFormRefImpl camundaFormRef = new CamundaFormRefImpl(ref.getKey(), ref.getBinding());
+    camundaFormRef.setVersion(ref.getVersion());
+    return camundaFormRef;
   }
 
 }

--- a/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
@@ -425,6 +425,9 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
       .body("fluxnovaFormRef.key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
       .body("fluxnovaFormRef.binding", equalTo(MockProvider.EXAMPLE_FORM_REF_BINDING))
       .body("fluxnovaFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
+      .body("camundaFormRef.key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
+      .body("camundaFormRef.binding", equalTo(MockProvider.EXAMPLE_FORM_REF_BINDING))
+      .body("camundaFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
     .when().get(START_FORM_URL);
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/TaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/TaskRestServiceInteractionTest.java
@@ -758,6 +758,7 @@ public class TaskRestServiceInteractionTest extends
       .then().expect().statusCode(Status.OK.getStatusCode())
       .body("key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
       .body("fluxnovaFormRef", nullValue())
+      .body("camundaFormRef", nullValue())
       .body("contextPath", equalTo(MockProvider.EXAMPLE_PROCESS_APPLICATION_CONTEXT_PATH))
       .when().get(TASK_FORM_URL);
   }
@@ -771,6 +772,9 @@ public class TaskRestServiceInteractionTest extends
         .body("fluxnovaFormRef.key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
         .body("fluxnovaFormRef.binding", equalTo(MockProvider.EXAMPLE_FORM_REF_BINDING))
         .body("fluxnovaFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
+        .body("camundaFormRef.key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
+        .body("camundaFormRef.binding", equalTo(MockProvider.EXAMPLE_FORM_REF_BINDING))
+        .body("camundaFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
         .body("key", nullValue())
       .when().get(SINGLE_TASK_URL);
   }
@@ -802,6 +806,9 @@ public class TaskRestServiceInteractionTest extends
        .body("fluxnovaFormRef.key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
        .body("fluxnovaFormRef.binding", equalTo(MockProvider.EXAMPLE_FORM_REF_BINDING))
        .body("fluxnovaFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
+       .body("camundaFormRef.key", equalTo(MockProvider.EXAMPLE_FORM_KEY))
+       .body("camundaFormRef.binding", equalTo(MockProvider.EXAMPLE_FORM_REF_BINDING))
+       .body("camundaFormRef.version", equalTo(MockProvider.EXAMPLE_FORM_REF_VERSION))
        .body("key", nullValue())
        .body("contextPath", equalTo(MockProvider.EXAMPLE_PROCESS_APPLICATION_CONTEXT_PATH))
      .when().get(TASK_FORM_URL);

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/form/CamundaFormRef.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/form/CamundaFormRef.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.finos.fluxnova.bpm.engine.form;
+
+/**
+ * A {@link CamundaFormRef} represents a reference to a deployed Camunda Form.
+ */
+public interface CamundaFormRef {
+
+  /**
+   * The key of a {@link CamundaFormRef} corresponds to the {@code id} attribute
+   * in the Camunda Forms JSON.
+   */
+  String getKey();
+
+  /**
+   * The binding of {@link CamundaFormRef} specifies which version of the form
+   * to reference. Possible values are: {@code latest}, {@code deployment} and
+   * {@code version} (specific version value can be retrieved with {@link #getVersion()}).
+   */
+  String getBinding();
+
+  /**
+   * If the {@link #getBinding() binding} of a {@link CamundaFormRef} is set to
+   * {@code version}, the specific version is returned.
+   */
+  Integer getVersion();
+}

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/form/CamundaFormRefImpl.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/form/CamundaFormRefImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.finos.fluxnova.bpm.engine.impl.form;
+
+import org.finos.fluxnova.bpm.engine.form.CamundaFormRef;
+
+public class CamundaFormRefImpl implements CamundaFormRef {
+
+  String key;
+  String binding;
+  Integer version;
+
+  public CamundaFormRefImpl(String key, String binding) {
+    this.key = key;
+    this.binding = binding;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public String getBinding() {
+    return binding;
+  }
+
+  public void setBinding(String binding) {
+    this.binding = binding;
+  }
+
+  public Integer getVersion() {
+    return version;
+  }
+
+  public void setVersion(Integer version) {
+    this.version = version;
+  }
+
+  @Override
+  public String toString() {
+    return "CamundaFormRefImpl [key=" + key + ", binding=" + binding + ", version=" + version + "]";
+  }
+}


### PR DESCRIPTION
Related to Issue: https://github.com/finos/fluxnova-bpm-platform/issues/146

This pull request introduces a new (deprecated) camundaFormRef property to several DTOs and API responses, providing backward compatibility for referencing Camunda Forms alongside the newer fluxnovaFormRef. The changes include new model templates, Java DTO updates, OpenAPI schema/template updates, and additional test coverage to ensure the correct serialization of the new property. The most important changes are summarized below:

API and Model Changes:

Added a new CamundaFormRef model and corresponding FreeMarker template (CamundaFormRef.ftl) to represent references to Camunda Forms. This is used as a deprecated property in relevant DTOs.
Updated FormDto, TaskDto, and HalTask Java classes to include a deprecated camundaFormRef property, with conversion logic from fluxnovaFormRef, and updated getters/setters.
OpenAPI/REST Template Updates:

Updated OpenAPI/REST templates to include the deprecated camundaFormRef property in schema definitions and example responses for tasks and forms.
Test Coverage:

Extended integration tests to verify the presence and correct serialization of the camundaFormRef property in API responses, ensuring backward compatibility and correct mapping from fluxnovaFormRef.
These changes ensure a smooth transition for clients still relying on the legacy Camunda Form reference while promoting the use of the new fluxnovaFormRef property.