### PR TITLE
added extra attributes to the ProcessEngineDTO and made them accessible via the api through a allNamingDetails attribute

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/finos/fluxnova/bpm/engine/rest/dto/ProcessEngineDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/finos/fluxnova/bpm/engine/rest/dto/ProcessEngineDto.ftl
@@ -9,17 +9,17 @@
   <@lib.property
       name = "description"
       type = "string"
-      desc = "The description of the process engine. Only present when `allNamingDetails=true`." />
+      desc = "The description of the process engine. Only present when set in engine." />
 
   <@lib.property
       name = "groupName"
       type = "string"
-      desc = "The group name of the process engine. Only present when `allNamingDetails=true`." />
+      desc = "The group name of the process engine. Only present when set in engine." />
 
   <@lib.property
       name = "groupDescription"
       type = "string"
-      desc = "The group description of the process engine. Only present when `allNamingDetails=true`."
+      desc = "The group description of the process engine. Only present when set in engine."
       last=true />
 
 </@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/finos/fluxnova/bpm/engine/rest/dto/ProcessEngineDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/finos/fluxnova/bpm/engine/rest/dto/ProcessEngineDto.ftl
@@ -4,7 +4,22 @@
   <@lib.property
       name = "name"
       type = "string"
-      desc = "The name of the process engine."
+      desc = "The name of the process engine." />
+
+  <@lib.property
+      name = "description"
+      type = "string"
+      desc = "The description of the process engine. Only present when `allNamingDetails=true`." />
+
+  <@lib.property
+      name = "groupName"
+      type = "string"
+      desc = "The group name of the process engine. Only present when `allNamingDetails=true`." />
+
+  <@lib.property
+      name = "groupDescription"
+      type = "string"
+      desc = "The group description of the process engine. Only present when `allNamingDetails=true`."
       last=true />
 
 </@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/finos/fluxnova/bpm/engine/rest/dto/ProcessEngineDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/finos/fluxnova/bpm/engine/rest/dto/ProcessEngineDto.ftl
@@ -7,19 +7,19 @@
       desc = "The name of the process engine." />
 
   <@lib.property
-      name = "description"
+      name = "displayName"
       type = "string"
-      desc = "The description of the process engine. Only present when set in engine." />
+      desc = "The display name of the process engine. Only present when set in engine." />
 
   <@lib.property
-      name = "groupName"
+      name = "group"
       type = "string"
       desc = "The group name of the process engine. Only present when set in engine." />
 
   <@lib.property
-      name = "groupDescription"
+      name = "groupDisplayName"
       type = "string"
-      desc = "The group description of the process engine. Only present when set in engine."
+      desc = "The group display name of the process engine. Only present when set in engine."
       last=true />
 
 </@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/engine/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/engine/get.ftl
@@ -1,11 +1,24 @@
 <#macro endpoint_macro docsUrl="">
 {
   <@lib.endpointInfo
-      id = "getProcessEngineNames"
+      id = "getProcessEngines"
       tag = "Engine"
       summary = "Get List"
       desc = "Retrieves the names of all process engines available on your platform.
+              If the query parameter `allNamingDetails` is set to `true`, each engine entry also includes
+              `description`, `groupName`, and `groupDescription`.
               **Note**: You cannot prepend `/engine/{name}` to this method." />
+
+  "parameters" : [
+    <@lib.parameter
+        name = "allNamingDetails"
+        location = "query"
+        type = "boolean"
+        required = false
+        last = true
+        desc = "Set to `true` to include `description`, `groupName`, and `groupDescription`.
+                Defaults to `false` (name-only response)."/>
+  ],
 
   "responses" : {
     <@lib.response
@@ -15,12 +28,30 @@
         last=true
         desc = "Request successful."
         examples = ['"example-1": {
+                       "summary": "Default response (name only)",
                        "value": [
                          {
                            "name": "default"
                          },
                          {
                            "name": "anotherEngineName"
+                         }
+                       ]
+                     },
+                     "example-2": {
+                       "summary": "Response with allNamingDetails=true",
+                       "value": [
+                         {
+                           "name": "default",
+                           "description": "default",
+                           "groupName": "default",
+                           "groupDescription": "default"
+                         },
+                         {
+                           "name": "anotherEngineName",
+                           "description": "anotherEngineDescription",
+                           "groupName": "anotherEngineGroupName",
+                           "groupDescription": "anotherEngineGroupDescription"
                          }
                        ]
                      }'] />

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/engine/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/engine/get.ftl
@@ -33,15 +33,15 @@
                        "value": [
                          {
                            "name": "default",
-                           "description": "default",
-                           "groupName": "default",
+                           "displayName": "default",
+                           "group": "default",
                            "groupDescription": "default"
                          },
                          {
                            "name": "anotherEngineName",
-                           "description": "anotherEngineDescription",
-                           "groupName": "anotherEngineGroupName",
-                           "groupDescription": "anotherEngineGroupDescription"
+                           "displayName": "anotherEngineDescription",
+                           "group": "anotherEngineGroupName",
+                           "groupDisplayName": "anotherEngineGroupDescription"
                          }
                        ]
                      }'] />

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/engine/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/engine/get.ftl
@@ -6,7 +6,7 @@
       summary = "Get List"
       desc = "Retrieves the names of all process engines available on your platform.
               If the engine is configured with them the entry also includes
-              `description`, `groupName`, and `groupDescription`.
+              `displayName`, `group`, and `groupDisplayName`.
               **Note**: You cannot prepend `/engine/{name}` to this method." />
 
   "parameters" : [],
@@ -35,7 +35,7 @@
                            "name": "default",
                            "displayName": "default",
                            "group": "default",
-                           "groupDescription": "default"
+                           "groupDisplayName": "default"
                          },
                          {
                            "name": "anotherEngineName",

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/engine/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/engine/get.ftl
@@ -5,21 +5,11 @@
       tag = "Engine"
       summary = "Get List"
       desc = "Retrieves the names of all process engines available on your platform.
-              If the query parameter `allNamingDetails` is set to `true`, each engine entry also includes
+              If the engine is configured with them the entry also includes
               `description`, `groupName`, and `groupDescription`.
               **Note**: You cannot prepend `/engine/{name}` to this method." />
 
-  "parameters" : [
-    <@lib.parameter
-        name = "allNamingDetails"
-        location = "query"
-        type = "boolean"
-        required = false
-        last = true
-        desc = "Set to `true` to include `description`, `groupName`, and `groupDescription`.
-                Defaults to `false` (name-only response)."/>
-  ],
-
+  "parameters" : [],
   "responses" : {
     <@lib.response
         code = "200"
@@ -28,7 +18,7 @@
         last=true
         desc = "Request successful."
         examples = ['"example-1": {
-                       "summary": "Default response (name only)",
+                       "summary": "Default response (name only) without extra configuration",
                        "value": [
                          {
                            "name": "default"
@@ -39,7 +29,7 @@
                        ]
                      },
                      "example-2": {
-                       "summary": "Response with allNamingDetails=true",
+                       "summary": "Response with new configuration",
                        "value": [
                          {
                            "name": "default",

--- a/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/dto/ProcessEngineDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/dto/ProcessEngineDto.java
@@ -16,9 +16,17 @@
  */
 package org.finos.fluxnova.bpm.engine.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 public class ProcessEngineDto {
 
   private String name;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String description;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String groupName;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private String groupDescription;
 
   public String getName() {
     return name;
@@ -27,4 +35,29 @@ public class ProcessEngineDto {
   public void setName(String name) {
     this.name = name;
   }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getGroupName() {
+    return groupName;
+  }
+
+  public void setGroupName(String groupName) {
+    this.groupName = groupName;
+  }
+
+  public String getGroupDescription() {
+    return groupDescription;
+  }
+
+  public void setGroupDescription(String groupDescription) {
+    this.groupDescription = groupDescription;
+  }
+
 }

--- a/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/dto/ProcessEngineDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/dto/ProcessEngineDto.java
@@ -22,11 +22,11 @@ public class ProcessEngineDto {
 
   private String name;
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private String description;
+  private String displayName;
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private String groupName;
+  private String group;
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  private String groupDescription;
+  private String groupDisplayName;
 
   public String getName() {
     return name;
@@ -36,28 +36,28 @@ public class ProcessEngineDto {
     this.name = name;
   }
 
-  public String getDescription() {
-    return description;
+  public String getDisplayName() {
+    return displayName;
   }
 
-  public void setDescription(String description) {
-    this.description = description;
+  public void setDisplayName(String displayName) {
+    this.displayName = displayName;
   }
 
-  public String getGroupName() {
-    return groupName;
+  public String getGroup() {
+    return group;
   }
 
-  public void setGroupName(String groupName) {
-    this.groupName = groupName;
+  public void setGroup(String group) {
+    this.group = group;
   }
 
-  public String getGroupDescription() {
-    return groupDescription;
+  public String getGroupDisplayName() {
+    return groupDisplayName;
   }
 
-  public void setGroupDescription(String groupDescription) {
-    this.groupDescription = groupDescription;
+  public void setGroupDisplayName(String groupDisplayName) {
+    this.groupDisplayName = groupDisplayName;
   }
 
 }

--- a/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/impl/NamedProcessEngineRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/impl/NamedProcessEngineRestServiceImpl.java
@@ -23,12 +23,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
 
@@ -297,9 +295,9 @@ public class NamedProcessEngineRestServiceImpl extends AbstractProcessEngineRest
         ProcessEngine engine = entry.getValue();
         ProcessEngineDto dto = new ProcessEngineDto();
         dto.setName(engine.getName());
-        dto.setDescription(engine.getDescription());
-        dto.setGroupName(engine.getGroupName());
-        dto.setGroupDescription(engine.getGroupDescription());
+        dto.setDisplayName(engine.getDisplayName());
+        dto.setGroup(engine.getGroup());
+        dto.setGroupDisplayName(engine.getGroupDisplayName());
         results.add(dto);
       }
 

--- a/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/impl/NamedProcessEngineRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/impl/NamedProcessEngineRestServiceImpl.java
@@ -286,30 +286,23 @@ public class NamedProcessEngineRestServiceImpl extends AbstractProcessEngineRest
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  public List<ProcessEngineDto> getProcessEngines(
-      @QueryParam("allNamingDetails") @DefaultValue("false") boolean allNamingDetails) {
+  public List<ProcessEngineDto> getProcessEngines() {
     ProcessEngineProvider provider = getProcessEngineProvider();
 
     List<ProcessEngineDto> results = new ArrayList<ProcessEngineDto>();
 
-    if (allNamingDetails) {
+
       Map<String, ProcessEngine> engines = provider.getProcessEngines();
       for (Map.Entry<String, ProcessEngine> entry : engines.entrySet()) {
         ProcessEngine engine = entry.getValue();
         ProcessEngineDto dto = new ProcessEngineDto();
         dto.setName(engine.getName());
-        dto.setDescription(engine.getDescription() != null ? engine.getDescription() : "");
-        dto.setGroupName(engine.getGroupName() != null ? engine.getGroupName() : "");
-        dto.setGroupDescription(engine.getGroupDescription() != null ? engine.getGroupDescription() : "");
+        dto.setDescription(engine.getDescription());
+        dto.setGroupName(engine.getGroupName());
+        dto.setGroupDescription(engine.getGroupDescription());
         results.add(dto);
       }
-    } else {
-      for (String engineName : provider.getProcessEngineNames()) {
-        ProcessEngineDto dto = new ProcessEngineDto();
-        dto.setName(engineName);
-        results.add(dto);
-      }
-    }
+
 
     return results;
   }

--- a/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/impl/NamedProcessEngineRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/impl/NamedProcessEngineRestServiceImpl.java
@@ -21,15 +21,18 @@ import static org.finos.fluxnova.bpm.engine.rest.util.EngineUtil.getProcessEngin
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
 
+import org.finos.fluxnova.bpm.engine.ProcessEngine;
 import org.finos.fluxnova.bpm.engine.rest.AuthorizationRestService;
 import org.finos.fluxnova.bpm.engine.rest.BatchRestService;
 import org.finos.fluxnova.bpm.engine.rest.BulkTaskRestService;
@@ -283,15 +286,29 @@ public class NamedProcessEngineRestServiceImpl extends AbstractProcessEngineRest
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  public List<ProcessEngineDto> getProcessEngineNames() {
+  public List<ProcessEngineDto> getProcessEngines(
+      @QueryParam("allNamingDetails") @DefaultValue("false") boolean allNamingDetails) {
     ProcessEngineProvider provider = getProcessEngineProvider();
-    Set<String> engineNames = provider.getProcessEngineNames();
 
     List<ProcessEngineDto> results = new ArrayList<ProcessEngineDto>();
-    for (String engineName : engineNames) {
-      ProcessEngineDto dto = new ProcessEngineDto();
-      dto.setName(engineName);
-      results.add(dto);
+
+    if (allNamingDetails) {
+      Map<String, ProcessEngine> engines = provider.getProcessEngines();
+      for (Map.Entry<String, ProcessEngine> entry : engines.entrySet()) {
+        ProcessEngine engine = entry.getValue();
+        ProcessEngineDto dto = new ProcessEngineDto();
+        dto.setName(engine.getName());
+        dto.setDescription(engine.getDescription() != null ? engine.getDescription() : "");
+        dto.setGroupName(engine.getGroupName() != null ? engine.getGroupName() : "");
+        dto.setGroupDescription(engine.getGroupDescription() != null ? engine.getGroupDescription() : "");
+        results.add(dto);
+      }
+    } else {
+      for (String engineName : provider.getProcessEngineNames()) {
+        ProcessEngineDto dto = new ProcessEngineDto();
+        dto.setName(engineName);
+        results.add(dto);
+      }
     }
 
     return results;

--- a/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/impl/application/ContainerManagedProcessEngineProvider.java
+++ b/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/impl/application/ContainerManagedProcessEngineProvider.java
@@ -22,6 +22,7 @@ import org.finos.fluxnova.bpm.engine.ProcessEngine;
 import org.finos.fluxnova.bpm.engine.ProcessEngines;
 import org.finos.fluxnova.bpm.engine.rest.spi.ProcessEngineProvider;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -49,6 +50,11 @@ public class ContainerManagedProcessEngineProvider implements ProcessEngineProvi
   @Override
   public Set<String> getProcessEngineNames() {
     return ProcessEngines.getProcessEngines().keySet();
+  }
+
+  @Override
+  public Map<String, ProcessEngine> getProcessEngines() {
+    return ProcessEngines.getProcessEngines();
   }
 
 }

--- a/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/spi/ProcessEngineProvider.java
+++ b/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/spi/ProcessEngineProvider.java
@@ -18,6 +18,7 @@ package org.finos.fluxnova.bpm.engine.rest.spi;
 
 import org.finos.fluxnova.bpm.engine.ProcessEngine;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -42,5 +43,10 @@ public interface ProcessEngineProvider {
    * Returns the name of all known process engines. Returns an empty set if no engines are accessible.
    */
   Set<String> getProcessEngineNames();
+
+  /**
+   * Returns engine objects that are accessible through this provider, keyed by engine name.
+   */
+  Map<String, ProcessEngine> getProcessEngines();
 
 }

--- a/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/EnginesRestTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/EnginesRestTest.java
@@ -18,7 +18,7 @@ import io.restassured.http.ContentType;
 
 /**
  * Tests for the /engine endpoint that retrieves list of process engines.
- * Attributes description, groupName and groupDescription are only included in
+ * Attributes displayName, group and groupDisplayName are only included in
  * the response when the engine returns a non-null value for them. The name
  * attribute is always present.
  */
@@ -32,14 +32,14 @@ public class EnginesRestTest extends AbstractRestServiceTest {
   @Test
   public void shouldAlwaysReturnNameAndOmitUnsetAttributes() {
     ProcessEngine defaultEngine = getProcessEngine(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME);
-    when(defaultEngine.getDescription()).thenReturn(null);
-    when(defaultEngine.getGroupName()).thenReturn(null);
-    when(defaultEngine.getGroupDescription()).thenReturn(null);
+    when(defaultEngine.getDisplayName()).thenReturn(null);
+    when(defaultEngine.getGroup()).thenReturn(null);
+    when(defaultEngine.getGroupDisplayName()).thenReturn(null);
 
     ProcessEngine anotherEngine = getProcessEngine(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME);
-    when(anotherEngine.getDescription()).thenReturn(null);
-    when(anotherEngine.getGroupName()).thenReturn(null);
-    when(anotherEngine.getGroupDescription()).thenReturn(null);
+    when(anotherEngine.getDisplayName()).thenReturn(null);
+    when(anotherEngine.getGroup()).thenReturn(null);
+    when(anotherEngine.getGroupDisplayName()).thenReturn(null);
 
     given()
       .accept(ContentType.JSON)
@@ -49,25 +49,25 @@ public class EnginesRestTest extends AbstractRestServiceTest {
       .statusCode(Status.OK.getStatusCode())
       .body("", hasSize(2))
       .body("name", hasItems(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME, MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('description')", equalTo(false))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupName')", equalTo(false))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupDescription')", equalTo(false))
-      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('description')", equalTo(false))
-      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupName')", equalTo(false))
-      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupDescription')", equalTo(false));
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('displayName')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('group')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupDisplayName')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('displayName')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('group')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupDisplayName')", equalTo(false));
   }
 
   @Test
   public void shouldReturnAttributesWhenSetOnEngine() {
     ProcessEngine defaultEngine = getProcessEngine(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME);
-    when(defaultEngine.getDescription()).thenReturn("defaultDescription");
-    when(defaultEngine.getGroupName()).thenReturn("defaultGroupName");
-    when(defaultEngine.getGroupDescription()).thenReturn("defaultGroupDescription");
+    when(defaultEngine.getDisplayName()).thenReturn("defaultDisplayName");
+    when(defaultEngine.getGroup()).thenReturn("defaultGroupName");
+    when(defaultEngine.getGroupDisplayName()).thenReturn("defaultGroupDisplayName");
 
     ProcessEngine anotherEngine = getProcessEngine(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME);
-    when(anotherEngine.getDescription()).thenReturn("anotherDescription");
-    when(anotherEngine.getGroupName()).thenReturn("anotherGroupName");
-    when(anotherEngine.getGroupDescription()).thenReturn("anotherGroupDescription");
+    when(anotherEngine.getDisplayName()).thenReturn("anotherDisplayName");
+    when(anotherEngine.getGroup()).thenReturn("anotherGroupName");
+    when(anotherEngine.getGroupDisplayName()).thenReturn("anotherGroupDisplayName");
 
     given()
       .accept(ContentType.JSON)
@@ -77,25 +77,25 @@ public class EnginesRestTest extends AbstractRestServiceTest {
       .statusCode(Status.OK.getStatusCode())
       .body("", hasSize(2))
       .body("name", hasItems(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME, MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo("defaultDescription"))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo("defaultGroupName"))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo("defaultGroupDescription"))
-      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo("anotherDescription"))
-      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo("anotherGroupName"))
-      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo("anotherGroupDescription"));
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.displayName", equalTo("defaultDisplayName"))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.group", equalTo("defaultGroupName"))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDisplayName", equalTo("defaultGroupDisplayName"))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.displayName", equalTo("anotherDisplayName"))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.group", equalTo("anotherGroupName"))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDisplayName", equalTo("anotherGroupDisplayName"));
   }
 
   @Test
   public void shouldOnlyReturnSetAttributesWhenSomeAreNull() {
     ProcessEngine defaultEngine = getProcessEngine(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME);
-    when(defaultEngine.getDescription()).thenReturn(null);
-    when(defaultEngine.getGroupName()).thenReturn(null);
-    when(defaultEngine.getGroupDescription()).thenReturn(null);
+    when(defaultEngine.getDisplayName()).thenReturn(null);
+    when(defaultEngine.getGroup()).thenReturn(null);
+    when(defaultEngine.getGroupDisplayName()).thenReturn(null);
 
     ProcessEngine anotherEngine = getProcessEngine(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME);
-    when(anotherEngine.getDescription()).thenReturn("anotherDescription");
-    when(anotherEngine.getGroupName()).thenReturn("anotherGroupName");
-    when(anotherEngine.getGroupDescription()).thenReturn("anotherGroupDescription");
+    when(anotherEngine.getDisplayName()).thenReturn("anotherDisplayName");
+    when(anotherEngine.getGroup()).thenReturn("anotherGroupName");
+    when(anotherEngine.getGroupDisplayName()).thenReturn("anotherGroupDisplayName");
 
     given()
       .accept(ContentType.JSON)
@@ -105,11 +105,11 @@ public class EnginesRestTest extends AbstractRestServiceTest {
       .statusCode(Status.OK.getStatusCode())
       .body("", hasSize(2))
       .body("name", hasItems(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME, MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('description')", equalTo(false))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupName')", equalTo(false))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupDescription')", equalTo(false))
-      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo("anotherDescription"))
-      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo("anotherGroupName"))
-      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo("anotherGroupDescription"));
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('displayName')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('group')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupDisplayName')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.displayName", equalTo("anotherDisplayName"))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.group", equalTo("anotherGroupName"))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDisplayName", equalTo("anotherGroupDisplayName"));
   }
 }

--- a/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/EnginesRestTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/EnginesRestTest.java
@@ -17,7 +17,10 @@ import org.junit.Test;
 import io.restassured.http.ContentType;
 
 /**
- * Tests for the /engine endpoint that retrieves list of process engines
+ * Tests for the /engine endpoint that retrieves list of process engines.
+ * Attributes description, groupName and groupDescription are only included in
+ * the response when the engine returns a non-null value for them. The name
+ * attribute is always present.
  */
 public class EnginesRestTest extends AbstractRestServiceTest {
 
@@ -27,7 +30,17 @@ public class EnginesRestTest extends AbstractRestServiceTest {
   protected static final String ENGINES_URL = TEST_RESOURCE_ROOT_PATH + "/engine";
 
   @Test
-  public void shouldNotProvideAllNamingDetailsWhenNotRequested() {
+  public void shouldAlwaysReturnNameAndOmitUnsetAttributes() {
+    ProcessEngine defaultEngine = getProcessEngine(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME);
+    when(defaultEngine.getDescription()).thenReturn(null);
+    when(defaultEngine.getGroupName()).thenReturn(null);
+    when(defaultEngine.getGroupDescription()).thenReturn(null);
+
+    ProcessEngine anotherEngine = getProcessEngine(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME);
+    when(anotherEngine.getDescription()).thenReturn(null);
+    when(anotherEngine.getGroupName()).thenReturn(null);
+    when(anotherEngine.getGroupDescription()).thenReturn(null);
+
     given()
       .accept(ContentType.JSON)
     .when()
@@ -45,26 +58,35 @@ public class EnginesRestTest extends AbstractRestServiceTest {
   }
 
   @Test
-  public void shouldProvideAllNamingDetailsWhenRequested() {
+  public void shouldReturnAttributesWhenSetOnEngine() {
+    ProcessEngine defaultEngine = getProcessEngine(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME);
+    when(defaultEngine.getDescription()).thenReturn("defaultDescription");
+    when(defaultEngine.getGroupName()).thenReturn("defaultGroupName");
+    when(defaultEngine.getGroupDescription()).thenReturn("defaultGroupDescription");
+
+    ProcessEngine anotherEngine = getProcessEngine(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME);
+    when(anotherEngine.getDescription()).thenReturn("anotherDescription");
+    when(anotherEngine.getGroupName()).thenReturn("anotherGroupName");
+    when(anotherEngine.getGroupDescription()).thenReturn("anotherGroupDescription");
+
     given()
       .accept(ContentType.JSON)
-      .queryParam("allNamingDetails", true)
     .when()
       .get(ENGINES_URL)
     .then()
       .statusCode(Status.OK.getStatusCode())
       .body("", hasSize(2))
       .body("name", hasItems(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME, MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME))
-      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME))
-      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME))
-      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME));
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo("defaultDescription"))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo("defaultGroupName"))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo("defaultGroupDescription"))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo("anotherDescription"))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo("anotherGroupName"))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo("anotherGroupDescription"));
   }
 
   @Test
-  public void shouldDefaultDescriptionsToEmptyWhenAllDetailsTrueAndValueIsNull() {
+  public void shouldOnlyReturnSetAttributesWhenSomeAreNull() {
     ProcessEngine defaultEngine = getProcessEngine(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME);
     when(defaultEngine.getDescription()).thenReturn(null);
     when(defaultEngine.getGroupName()).thenReturn(null);
@@ -77,15 +99,15 @@ public class EnginesRestTest extends AbstractRestServiceTest {
 
     given()
       .accept(ContentType.JSON)
-      .queryParam("allNamingDetails", true)
     .when()
       .get(ENGINES_URL)
     .then()
       .statusCode(Status.OK.getStatusCode())
       .body("", hasSize(2))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo(""))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo(""))
-      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo(""))
+      .body("name", hasItems(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME, MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('description')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupName')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupDescription')", equalTo(false))
       .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo("anotherDescription"))
       .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo("anotherGroupName"))
       .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo("anotherGroupDescription"));

--- a/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/EnginesRestTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/EnginesRestTest.java
@@ -1,0 +1,93 @@
+package org.finos.fluxnova.bpm.engine.rest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.finos.fluxnova.bpm.engine.ProcessEngine;
+import org.finos.fluxnova.bpm.engine.rest.helper.MockProvider;
+import org.finos.fluxnova.bpm.engine.rest.util.container.TestContainerRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import io.restassured.http.ContentType;
+
+/**
+ * Tests for the /engine endpoint that retrieves list of process engines
+ */
+public class EnginesRestTest extends AbstractRestServiceTest {
+
+  @ClassRule
+  public static TestContainerRule rule = new TestContainerRule();
+
+  protected static final String ENGINES_URL = TEST_RESOURCE_ROOT_PATH + "/engine";
+
+  @Test
+  public void shouldNotProvideAllNamingDetailsWhenNotRequested() {
+    given()
+      .accept(ContentType.JSON)
+    .when()
+      .get(ENGINES_URL)
+    .then()
+      .statusCode(Status.OK.getStatusCode())
+      .body("", hasSize(2))
+      .body("name", hasItems(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME, MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('description')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupName')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupDescription')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('description')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupName')", equalTo(false))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.containsKey('groupDescription')", equalTo(false));
+  }
+
+  @Test
+  public void shouldProvideAllNamingDetailsWhenRequested() {
+    given()
+      .accept(ContentType.JSON)
+      .queryParam("allNamingDetails", true)
+    .when()
+      .get(ENGINES_URL)
+    .then()
+      .statusCode(Status.OK.getStatusCode())
+      .body("", hasSize(2))
+      .body("name", hasItems(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME, MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME));
+  }
+
+  @Test
+  public void shouldDefaultDescriptionsToEmptyWhenAllDetailsTrueAndValueIsNull() {
+    ProcessEngine defaultEngine = getProcessEngine(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME);
+    when(defaultEngine.getDescription()).thenReturn(null);
+    when(defaultEngine.getGroupName()).thenReturn(null);
+    when(defaultEngine.getGroupDescription()).thenReturn(null);
+
+    ProcessEngine anotherEngine = getProcessEngine(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME);
+    when(anotherEngine.getDescription()).thenReturn("anotherDescription");
+    when(anotherEngine.getGroupName()).thenReturn("anotherGroupName");
+    when(anotherEngine.getGroupDescription()).thenReturn("anotherGroupDescription");
+
+    given()
+      .accept(ContentType.JSON)
+      .queryParam("allNamingDetails", true)
+    .when()
+      .get(ENGINES_URL)
+    .then()
+      .statusCode(Status.OK.getStatusCode())
+      .body("", hasSize(2))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo(""))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo(""))
+      .body("find { it.name == '" + MockProvider.EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo(""))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.description", equalTo("anotherDescription"))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupName", equalTo("anotherGroupName"))
+      .body("find { it.name == '" + MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME + "' }.groupDescription", equalTo("anotherGroupDescription"));
+  }
+}

--- a/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/ProcessEngineRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/ProcessEngineRestServiceTest.java
@@ -165,7 +165,7 @@ public class ProcessEngineRestServiceTest extends
   protected static final String HISTORY_JOB_LOG_URL = HISTORY_URL + "/job-log";
   protected static final String HISTORY_EXTERNAL_TASK_LOG_URL = HISTORY_URL + "/external-task-log";
 
-  protected static final String EXAMPLE_ENGINE_NAME = "anEngineName";
+  protected static final String EXAMPLE_ENGINE_NAME = "anotherEngineName";
 
   private ProcessEngine namedProcessEngine;
   private RepositoryService mockRepoService;

--- a/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/spi/impl/MockedProcessEngineProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/spi/impl/MockedProcessEngineProvider.java
@@ -54,9 +54,9 @@ public class MockedProcessEngineProvider implements ProcessEngineProvider {
   private ProcessEngine mockProcessEngine(String engineName) {
     ProcessEngine engine = mock(ProcessEngine.class);
     when(engine.getName()).thenReturn(engineName);
-    when(engine.getDescription()).thenReturn(engineName);
-    when(engine.getGroupName()).thenReturn(engineName);
-    when(engine.getGroupDescription()).thenReturn(engineName);
+    when(engine.getDisplayName()).thenReturn(engineName);
+    when(engine.getGroup()).thenReturn(engineName);
+    when(engine.getGroupDisplayName()).thenReturn(engineName);
     mockServices(engine);
     mockProcessEngineConfiguration(engine);
     return engine;

--- a/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/spi/impl/MockedProcessEngineProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/spi/impl/MockedProcessEngineProvider.java
@@ -44,16 +44,19 @@ import org.finos.fluxnova.bpm.engine.variable.type.ValueTypeResolver;
 public class MockedProcessEngineProvider implements ProcessEngineProvider {
 
   private static ProcessEngine cachedDefaultProcessEngine;
-  private static Map<String, ProcessEngine> cachedEngines = new HashMap<String, ProcessEngine>();
+  private static Map<String, ProcessEngine> cachedEngines = new HashMap<>();
 
   public void resetEngines() {
     cachedDefaultProcessEngine = null;
-    cachedEngines = new HashMap<String, ProcessEngine>();
+    cachedEngines = new HashMap<>();
   }
 
   private ProcessEngine mockProcessEngine(String engineName) {
     ProcessEngine engine = mock(ProcessEngine.class);
     when(engine.getName()).thenReturn(engineName);
+    when(engine.getDescription()).thenReturn(engineName);
+    when(engine.getGroupName()).thenReturn(engineName);
+    when(engine.getGroupDescription()).thenReturn(engineName);
     mockServices(engine);
     mockProcessEngineConfiguration(engine);
     return engine;
@@ -96,10 +99,7 @@ public class MockedProcessEngineProvider implements ProcessEngineProvider {
 
   @Override
   public ProcessEngine getDefaultProcessEngine() {
-    if (cachedDefaultProcessEngine == null) {
-      cachedDefaultProcessEngine = mockProcessEngine("default");
-    }
-
+    cachedDefaultProcessEngine = getOrCreateProcessEngine(MockProvider.EXAMPLE_PROCESS_ENGINE_NAME);
     return cachedDefaultProcessEngine;
   }
 
@@ -109,16 +109,29 @@ public class MockedProcessEngineProvider implements ProcessEngineProvider {
       return null;
     }
 
-    if (name.equals("default")) {
-      return getDefaultProcessEngine();
+    return getOrCreateProcessEngine(name);
+  }
+
+  @Override
+  public Map<String, ProcessEngine> getProcessEngines() {
+    Set<String> mockEngineNames = this.getProcessEngineNames();
+    for (String engineName : mockEngineNames) {
+      getOrCreateProcessEngine(engineName);
     }
 
-    if (cachedEngines.get(name) == null) {
-      ProcessEngine mock = mockProcessEngine(name);
-      cachedEngines.put(name, mock);
+    return cachedEngines;
+  }
+
+  protected ProcessEngine getOrCreateProcessEngine(String engineName) {
+    if (cachedEngines.get(engineName) == null) {
+      cachedEngines.put(engineName, mockProcessEngine(engineName));
     }
 
-    return cachedEngines.get(name);
+    if (MockProvider.EXAMPLE_PROCESS_ENGINE_NAME.equals(engineName)) {
+      cachedDefaultProcessEngine = cachedEngines.get(engineName);
+    }
+
+    return cachedEngines.get(engineName);
   }
 
   @Override
@@ -128,6 +141,5 @@ public class MockedProcessEngineProvider implements ProcessEngineProvider {
     result.add(MockProvider.ANOTHER_EXAMPLE_PROCESS_ENGINE_NAME);
     return result;
   }
-
 
 }

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/ProcessEngine.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/ProcessEngine.java
@@ -65,6 +65,15 @@ public interface ProcessEngine extends ProcessEngineServices {
    * The default name for a process engine is 'default */
   String getName();
 
+  /** Returns the description of the process engine */
+  String getDescription();
+
+  /** Returns the group name of the process engine */
+  String getGroupName();
+
+  /** Returns the group description of the process engine */
+  String getGroupDescription();
+
   void close();
 
   ProcessEngineConfiguration getProcessEngineConfiguration();

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/ProcessEngine.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/ProcessEngine.java
@@ -66,13 +66,13 @@ public interface ProcessEngine extends ProcessEngineServices {
   String getName();
 
   /** Returns the description of the process engine */
-  String getDescription();
+  String getDisplayName();
 
   /** Returns the group name of the process engine */
-  String getGroupName();
+  String getGroup();
 
   /** Returns the group description of the process engine */
-  String getGroupDescription();
+  String getGroupDisplayName();
 
   void close();
 

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/ProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/ProcessEngineConfiguration.java
@@ -202,6 +202,9 @@ public abstract class ProcessEngineConfiguration {
   public static final String AUTHORIZATION_CHECK_REVOKE_AUTO = "auto";
 
   protected String processEngineName = ProcessEngines.NAME_DEFAULT;
+  protected String processEngineDescription;
+  protected String processEngineGroupName;
+  protected String processEngineGroupDescription;
   protected int idBlockSize = 100;
   protected String history = HISTORY_DEFAULT;
   protected boolean jobExecutorActivate;

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/ProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/ProcessEngineConfiguration.java
@@ -202,9 +202,9 @@ public abstract class ProcessEngineConfiguration {
   public static final String AUTHORIZATION_CHECK_REVOKE_AUTO = "auto";
 
   protected String processEngineName = ProcessEngines.NAME_DEFAULT;
-  protected String processEngineDescription;
+  protected String processEngineDisplayName;
   protected String processEngineGroupName;
-  protected String processEngineGroupDescription;
+  protected String processEngineGroupDisplayName;
   protected int idBlockSize = 100;
   protected String history = HISTORY_DEFAULT;
   protected boolean jobExecutorActivate;

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/ProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/ProcessEngineConfiguration.java
@@ -203,7 +203,7 @@ public abstract class ProcessEngineConfiguration {
 
   protected String processEngineName = ProcessEngines.NAME_DEFAULT;
   protected String processEngineDisplayName;
-  protected String processEngineGroupName;
+  protected String processEngineGroup;
   protected String processEngineGroupDisplayName;
   protected int idBlockSize = 100;
   protected String history = HISTORY_DEFAULT;

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/ProcessEngineImpl.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/ProcessEngineImpl.java
@@ -55,9 +55,9 @@ public class ProcessEngineImpl implements ProcessEngine {
   private final static ProcessEngineLogger LOG = ProcessEngineLogger.INSTANCE;
 
   protected String name;
-  protected String description;
-  protected String groupName;
-  protected String groupDescription;
+  protected String displayName;
+  protected String group;
+  protected String groupDisplayName;
 
   protected RepositoryService repositoryService;
   protected RuntimeService runtimeService;
@@ -86,9 +86,9 @@ public class ProcessEngineImpl implements ProcessEngine {
 
     this.processEngineConfiguration = processEngineConfiguration;
     this.name = processEngineConfiguration.getProcessEngineName();
-    this.description = processEngineConfiguration.getProcessEngineDescription();
-    this.groupName = processEngineConfiguration.getProcessEngineGroup();
-    this.groupDescription = processEngineConfiguration.getProcessEngineGroupDescription();
+    this.displayName = processEngineConfiguration.getProcessEngineDisplayName();
+    this.group = processEngineConfiguration.getProcessEngineGroupName();
+    this.groupDisplayName = processEngineConfiguration.getProcessEngineGroupDisplayName();
 
 
     this.repositoryService = processEngineConfiguration.getRepositoryService();
@@ -186,16 +186,16 @@ public class ProcessEngineImpl implements ProcessEngine {
     return name;
   }
 
-  public String getDescription() {
-    return description;
+  public String getDisplayName() {
+    return displayName;
   }
 
-  public String getGroupName() {
-    return groupName;
+  public String getGroup() {
+    return group;
   }
 
-  public String getGroupDescription() {
-    return groupDescription;
+  public String getGroupDisplayName() {
+    return groupDisplayName;
   }
 
 

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/ProcessEngineImpl.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/ProcessEngineImpl.java
@@ -55,6 +55,9 @@ public class ProcessEngineImpl implements ProcessEngine {
   private final static ProcessEngineLogger LOG = ProcessEngineLogger.INSTANCE;
 
   protected String name;
+  protected String description;
+  protected String groupName;
+  protected String groupDescription;
 
   protected RepositoryService repositoryService;
   protected RuntimeService runtimeService;
@@ -83,6 +86,10 @@ public class ProcessEngineImpl implements ProcessEngine {
 
     this.processEngineConfiguration = processEngineConfiguration;
     this.name = processEngineConfiguration.getProcessEngineName();
+    this.description = processEngineConfiguration.getProcessEngineDescription();
+    this.groupName = processEngineConfiguration.getProcessEngineGroup();
+    this.groupDescription = processEngineConfiguration.getProcessEngineGroupDescription();
+
 
     this.repositoryService = processEngineConfiguration.getRepositoryService();
     this.runtimeService = processEngineConfiguration.getRuntimeService();
@@ -174,6 +181,23 @@ public class ProcessEngineImpl implements ProcessEngine {
 
     LOG.processEngineClosed(name);
   }
+
+  public String getEngineName() {
+    return name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getGroupName() {
+    return groupName;
+  }
+
+  public String getGroupDescription() {
+    return groupDescription;
+  }
+
 
   @Override
   public String getName() {

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/ProcessEngineImpl.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/ProcessEngineImpl.java
@@ -87,7 +87,7 @@ public class ProcessEngineImpl implements ProcessEngine {
     this.processEngineConfiguration = processEngineConfiguration;
     this.name = processEngineConfiguration.getProcessEngineName();
     this.displayName = processEngineConfiguration.getProcessEngineDisplayName();
-    this.group = processEngineConfiguration.getProcessEngineGroupName();
+    this.group = processEngineConfiguration.getprocessEngineGroup();
     this.groupDisplayName = processEngineConfiguration.getProcessEngineGroupDisplayName();
 
 

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/ProcessEngineImpl.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/ProcessEngineImpl.java
@@ -87,7 +87,7 @@ public class ProcessEngineImpl implements ProcessEngine {
     this.processEngineConfiguration = processEngineConfiguration;
     this.name = processEngineConfiguration.getProcessEngineName();
     this.displayName = processEngineConfiguration.getProcessEngineDisplayName();
-    this.group = processEngineConfiguration.getprocessEngineGroup();
+    this.group = processEngineConfiguration.getProcessEngineGroup();
     this.groupDisplayName = processEngineConfiguration.getProcessEngineGroupDisplayName();
 
 

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -2976,11 +2976,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return this;
   }
 
-  public String getprocessEngineGroup() {
+  public String getProcessEngineGroup() {
     return processEngineGroup;
   }
 
-  public ProcessEngineConfigurationImpl setprocessEngineGroup(String processEngineGroup) {
+  public ProcessEngineConfigurationImpl setProcessEngineGroup(String processEngineGroup) {
     this.processEngineGroup = processEngineGroup;
     return this;
   }

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -2971,8 +2971,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return processEngineDisplayName;
   }
 
-  public ProcessEngineConfigurationImpl setProcessEngineDisplayName(String processEngineDescriptio) {
-    this.processEngineDisplayName = processEngineDescriptio;
+  public ProcessEngineConfigurationImpl setProcessEngineDisplayName(String processEngineDisplayName) {
+    this.processEngineDisplayName = processEngineDisplayName;
     return this;
   }
 
@@ -2990,8 +2990,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
 
-  public ProcessEngineConfigurationImpl setProcessEngineGroupDisplayName(String processEngineGroupDescription) {
-    this.processEngineGroupDisplayName = processEngineGroupDescription;
+  public ProcessEngineConfigurationImpl setProcessEngineGroupDisplayName(String processEngineGroupDisplayName) {
+    this.processEngineGroupDisplayName = processEngineGroupDisplayName;
     return this;
   }
 

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -2941,6 +2941,18 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return processEngineName;
   }
 
+  public String getProcessEngineDescription() {
+    return processEngineDescription;
+  }
+
+  public String getProcessEngineGroup() {
+    return processEngineGroupName;
+  }
+
+  public String getProcessEngineGroupDescription() {
+    return processEngineGroupDescription;
+  }
+
   public HistoryLevel getHistoryLevel() {
     return historyLevel;
   }
@@ -2964,6 +2976,21 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   @Override
   public ProcessEngineConfigurationImpl setProcessEngineName(String processEngineName) {
     this.processEngineName = processEngineName;
+    return this;
+  }
+
+  public ProcessEngineConfigurationImpl setProcessEngineDescription(String processEngineDescriptio) {
+    this.processEngineDescription = processEngineDescriptio;
+    return this;
+  }
+
+  public ProcessEngineConfigurationImpl setProcessEngineGroupName(String processEngineGroupName) {
+    this.processEngineGroupName = processEngineGroupName;
+    return this;
+  }
+
+  public ProcessEngineConfigurationImpl setProcessEngineGroupDescription(String processEngineGroupDescription) {
+    this.processEngineGroupDescription = processEngineGroupDescription;
     return this;
   }
 

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -2935,24 +2935,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   // getters and setters //////////////////////////////////////////////////////
-
-  @Override
-  public String getProcessEngineName() {
-    return processEngineName;
-  }
-
-  public String getProcessEngineDescription() {
-    return processEngineDescription;
-  }
-
-  public String getProcessEngineGroup() {
-    return processEngineGroupName;
-  }
-
-  public String getProcessEngineGroupDescription() {
-    return processEngineGroupDescription;
-  }
-
   public HistoryLevel getHistoryLevel() {
     return historyLevel;
   }
@@ -2974,14 +2956,28 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   @Override
+  public String getProcessEngineName() {
+    return processEngineName;
+  }
+
+
+  @Override
   public ProcessEngineConfigurationImpl setProcessEngineName(String processEngineName) {
     this.processEngineName = processEngineName;
     return this;
   }
 
-  public ProcessEngineConfigurationImpl setProcessEngineDescription(String processEngineDescriptio) {
-    this.processEngineDescription = processEngineDescriptio;
+  public String getProcessEngineDisplayName() {
+    return processEngineDisplayName;
+  }
+
+  public ProcessEngineConfigurationImpl setProcessEngineDisplayName(String processEngineDescriptio) {
+    this.processEngineDisplayName = processEngineDescriptio;
     return this;
+  }
+
+  public String getProcessEngineGroupName() {
+    return processEngineGroupName;
   }
 
   public ProcessEngineConfigurationImpl setProcessEngineGroupName(String processEngineGroupName) {
@@ -2989,8 +2985,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return this;
   }
 
-  public ProcessEngineConfigurationImpl setProcessEngineGroupDescription(String processEngineGroupDescription) {
-    this.processEngineGroupDescription = processEngineGroupDescription;
+  public String getProcessEngineGroupDisplayName() {
+    return processEngineGroupDisplayName;
+  }
+
+
+  public ProcessEngineConfigurationImpl setProcessEngineGroupDisplayName(String processEngineGroupDescription) {
+    this.processEngineGroupDisplayName = processEngineGroupDescription;
     return this;
   }
 

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -2976,12 +2976,12 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return this;
   }
 
-  public String getProcessEngineGroupName() {
-    return processEngineGroupName;
+  public String getprocessEngineGroup() {
+    return processEngineGroup;
   }
 
-  public ProcessEngineConfigurationImpl setProcessEngineGroupName(String processEngineGroupName) {
-    this.processEngineGroupName = processEngineGroupName;
+  public ProcessEngineConfigurationImpl setprocessEngineGroup(String processEngineGroup) {
+    this.processEngineGroup = processEngineGroup;
     return this;
   }
 

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/finos/fluxnova/bpm/rest/beans/CustomProcessEngineProvider.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/finos/fluxnova/bpm/rest/beans/CustomProcessEngineProvider.java
@@ -20,6 +20,9 @@ import org.finos.fluxnova.bpm.BpmPlatform;
 import org.finos.fluxnova.bpm.engine.ProcessEngine;
 import org.finos.fluxnova.bpm.engine.rest.spi.ProcessEngineProvider;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class CustomProcessEngineProvider implements ProcessEngineProvider {
@@ -37,6 +40,16 @@ public class CustomProcessEngineProvider implements ProcessEngineProvider {
   @Override
   public Set<String> getProcessEngineNames() {
     return BpmPlatform.getProcessEngineService().getProcessEngineNames();
+  }
+
+  @Override
+  public Map<String, ProcessEngine> getProcessEngines() {
+    List<ProcessEngine> engines = BpmPlatform.getProcessEngineService().getProcessEngines();
+    Map<String, ProcessEngine> map = new HashMap<>();
+    for (ProcessEngine engine : engines) {
+      map.put(engine.getName(), engine);
+    }
+    return map;
   }
 
 }

--- a/spring-boot-starter/starter-rest/src/main/java/org/finos/fluxnova/bpm/spring/boot/starter/rest/spi/SpringBootProcessEngineProvider.java
+++ b/spring-boot-starter/starter-rest/src/main/java/org/finos/fluxnova/bpm/spring/boot/starter/rest/spi/SpringBootProcessEngineProvider.java
@@ -16,8 +16,8 @@
  */
 package org.finos.fluxnova.bpm.spring.boot.starter.rest.spi;
 
+import java.util.Map;
 import java.util.Set;
-
 
 import org.finos.fluxnova.bpm.engine.rest.spi.ProcessEngineProvider;
 import org.finos.fluxnova.bpm.engine.ProcessEngine;
@@ -38,6 +38,11 @@ public class SpringBootProcessEngineProvider implements ProcessEngineProvider {
   @Override
   public Set<String> getProcessEngineNames() {
     return ProcessEngines.getProcessEngines().keySet();
+  }
+
+  @Override
+  public Map<String, ProcessEngine> getProcessEngines() {
+    return ProcessEngines.getProcessEngines();
   }
 
 }

--- a/webapps/assembly/src/main/java/org/finos/fluxnova/bpm/monitoring/plugin/test/application/TestProcessEngineProvider.java
+++ b/webapps/assembly/src/main/java/org/finos/fluxnova/bpm/monitoring/plugin/test/application/TestProcessEngineProvider.java
@@ -16,6 +16,9 @@
  */
 package org.finos.fluxnova.bpm.monitoring.plugin.test.application;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.finos.fluxnova.bpm.BpmPlatform;
@@ -43,6 +46,16 @@ public class TestProcessEngineProvider implements ProcessEngineProvider {
   @Override
   public Set<String> getProcessEngineNames() {
     return BpmPlatform.getProcessEngineService().getProcessEngineNames();
+  }
+
+  @Override
+  public Map<String, ProcessEngine> getProcessEngines() {
+    List<ProcessEngine> engines = BpmPlatform.getProcessEngineService().getProcessEngines();
+    Map<String, ProcessEngine> map = new HashMap<>();
+    for (ProcessEngine engine : engines) {
+      map.put(engine.getName(), engine);
+    }
+    return map;
   }
 
 }

--- a/webapps/assembly/src/main/java/org/finos/fluxnova/bpm/webapp/impl/engine/ContainerManagedProcessEngineProvider.java
+++ b/webapps/assembly/src/main/java/org/finos/fluxnova/bpm/webapp/impl/engine/ContainerManagedProcessEngineProvider.java
@@ -21,6 +21,7 @@ import org.finos.fluxnova.bpm.engine.ProcessEngine;
 import org.finos.fluxnova.bpm.engine.ProcessEngines;
 import org.finos.fluxnova.bpm.engine.rest.spi.ProcessEngineProvider;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -49,6 +50,11 @@ public class ContainerManagedProcessEngineProvider implements ProcessEngineProvi
   @Override
   public Set<String> getProcessEngineNames() {
     return ProcessEngines.getProcessEngines().keySet();
+  }
+
+  @Override
+  public Map<String, ProcessEngine> getProcessEngines() {
+    return ProcessEngines.getProcessEngines();
   }
 
 }


### PR DESCRIPTION
1. enable the configuration of extra details (description, groupName,groupDescription) to an engine.
2. when engine-rest/engine api is hit the extra information to the requesting user assuming it has been configured with those extra details