### PR TITLE
Jackson Core EOL Fix

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -37,7 +37,7 @@
     <version.openjpa>2.4.3</version.openjpa>
     <version.hibernate>5.6.5.Final</version.hibernate>
     <version.hikaricp>4.0.3</version.hikaricp>
-    <version.jackson>2.15.2</version.jackson>
+    <version.jackson>2.19.2</version.jackson>
     <version.xml.bind-api>2.3.3</version.xml.bind-api>
     <version.xml.jaxb-impl>2.3.6</version.xml.jaxb-impl>
     <version.xml.jaxb-impl4>4.0.5</version.xml.jaxb-impl4>
@@ -126,6 +126,13 @@
         <version>${project.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+      	<groupId>com.fasterxml.jackson</groupId>
+      	<artifactId>jackson-bom</artifactId>
+     	<version>${version.jackson}</version> 
+      	<type>pom</type>
+      	<scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Bump Jackson dependencies to 2.19.2 across the repo to eliminate older Jackson artifacts