### PR TITLE
feat(engine): script preprocessing feature addition to fluxnova engine

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -116,6 +116,12 @@
       <artifactId>gson</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
+    </dependency>
+
     <!-- provided dependencies -->
 
     <dependency>

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -347,6 +347,8 @@ import org.finos.fluxnova.bpm.engine.impl.scripting.engine.ScriptingEngines;
 import org.finos.fluxnova.bpm.engine.impl.scripting.engine.VariableScopeResolverFactory;
 import org.finos.fluxnova.bpm.engine.impl.scripting.env.ScriptEnvResolver;
 import org.finos.fluxnova.bpm.engine.impl.scripting.env.ScriptingEnvironment;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.CompositeScriptPreprocessor;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
 import org.finos.fluxnova.bpm.engine.impl.telemetry.dto.DatabaseImpl;
 import org.finos.fluxnova.bpm.engine.impl.telemetry.dto.InternalsImpl;
 import org.finos.fluxnova.bpm.engine.impl.telemetry.dto.JdkImpl;
@@ -608,6 +610,10 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected boolean enableScriptEngineNashornCompatibility = false;
   protected boolean configureScriptEngineHostAccess = true;
   protected boolean skipIsolationLevelCheck = false;
+  private volatile boolean enableScriptPreprocessing = false;
+  private volatile List<ScriptPreprocessor> scriptPreprocessors;
+  private volatile ScriptPreprocessor effectiveScriptPreprocessor;
+  private final Object scriptPreprocessorLock = new Object();
 
   /**
    * When set to false, the following behavior changes:
@@ -4266,6 +4272,50 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     this.scriptFactory = scriptFactory;
   }
 
+  /**
+   * @return whether script preprocessing is enabled for script execution.
+   */
+  public boolean isEnableScriptPreprocessing() {
+    return enableScriptPreprocessing;
+  }
+
+  /**
+   * Enables/disables script preprocessing and resets the cached effective preprocessor.
+   */
+  public void setEnableScriptPreprocessing(boolean enableScriptPreprocessing) {
+    synchronized (scriptPreprocessorLock) {
+      this.enableScriptPreprocessing = enableScriptPreprocessing;
+      this.effectiveScriptPreprocessor = null;
+    }
+  }
+
+  /**
+   * @return a copy of configured preprocessors, or {@code null} when none are configured.
+   */
+  public List<ScriptPreprocessor> getScriptPreprocessors() {
+    synchronized (scriptPreprocessorLock) {
+      if (scriptPreprocessors == null) {
+        return null;
+      }
+      return new ArrayList<>(scriptPreprocessors);
+    }
+  }
+
+  /**
+   * Replaces configured preprocessors and resets the cached effective preprocessor.
+   */
+  public void setScriptPreprocessors(List<ScriptPreprocessor> scriptPreprocessors) {
+    synchronized (scriptPreprocessorLock) {
+      if (scriptPreprocessors == null) {
+        this.scriptPreprocessors = null;
+      } else {
+        this.scriptPreprocessors = new ArrayList<>(scriptPreprocessors);
+      }
+      this.effectiveScriptPreprocessor = null;
+    }
+  }
+
+
   public ScriptEngineResolver getScriptEngineResolver() {
     return scriptEngineResolver;
   }
@@ -5329,5 +5379,57 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   public ProcessEngineConfiguration setLegacyJobRetryBehaviorEnabled(boolean legacyJobRetryBehaviorEnabled) {
     this.legacyJobRetryBehaviorEnabled = legacyJobRetryBehaviorEnabled;
     return this;
+  }
+
+  /**
+   * Adds a preprocessor to the configured chain and invalidates the cached effective preprocessor.
+   */
+  public void addScriptPreprocessor(ScriptPreprocessor scriptPreprocessor) {
+    if (scriptPreprocessor == null) {
+      return;
+    }
+    synchronized (scriptPreprocessorLock) {
+      List<ScriptPreprocessor> updatedScriptPreprocessors = this.scriptPreprocessors == null
+          ? new ArrayList<>()
+          : new ArrayList<>(this.scriptPreprocessors);
+      updatedScriptPreprocessors.add(scriptPreprocessor);
+      this.scriptPreprocessors = updatedScriptPreprocessors;
+      this.effectiveScriptPreprocessor = null;
+    }
+  }
+
+  /**
+   * Returns the effective preprocessor for runtime use.
+   *
+   * @return {@code null} when preprocessing is disabled or no preprocessors are configured.
+   */
+  public ScriptPreprocessor getEffectiveScriptPreprocessor() {
+    if (!enableScriptPreprocessing) {
+      return null;
+    }
+    ScriptPreprocessor cached = effectiveScriptPreprocessor;
+    if (cached != null) {
+      return cached;
+    }
+
+    synchronized (scriptPreprocessorLock) {
+      if (!enableScriptPreprocessing) {
+        return null;
+      }
+
+      if (effectiveScriptPreprocessor == null) {
+        List<ScriptPreprocessor> configuredScriptPreprocessors = scriptPreprocessors;
+        if (configuredScriptPreprocessors == null || configuredScriptPreprocessors.isEmpty()) {
+          return null;
+        }
+
+        if (configuredScriptPreprocessors.size() == 1) {
+          effectiveScriptPreprocessor = configuredScriptPreprocessors.get(0);
+        } else {
+          effectiveScriptPreprocessor = new CompositeScriptPreprocessor(new ArrayList<>(configuredScriptPreprocessors));
+        }
+      }
+      return effectiveScriptPreprocessor;
+    }
   }
 }

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/CompiledExecutableScript.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/CompiledExecutableScript.java
@@ -30,7 +30,7 @@ public class CompiledExecutableScript extends ExecutableScript {
 
   private final static ScriptLogger LOG = ProcessEngineLogger.SCRIPT_LOGGER;
 
-  protected CompiledScript compiledScript;
+  protected volatile CompiledScript compiledScript;
 
   protected CompiledExecutableScript(String language) {
     this(language, null);
@@ -50,9 +50,13 @@ public class CompiledExecutableScript extends ExecutableScript {
   }
 
   public Object evaluate(ScriptEngine scriptEngine, VariableScope variableScope, Bindings bindings) {
+    return evaluateCompiledScript(getCompiledScript(), variableScope, bindings);
+  }
+
+  protected Object evaluateCompiledScript(CompiledScript compiledScript, VariableScope variableScope, Bindings bindings) {
     try {
       LOG.debugEvaluatingCompiledScript(language);
-      return getCompiledScript().eval(bindings);
+      return compiledScript.eval(bindings);
     } catch (ScriptException e) {
       if (e.getCause() instanceof BpmnError) {
         throw (BpmnError) e.getCause();

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/DynamicExecutableScript.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/DynamicExecutableScript.java
@@ -41,6 +41,7 @@ public abstract class DynamicExecutableScript extends ExecutableScript {
 
   public Object evaluate(ScriptEngine scriptEngine, VariableScope variableScope, Bindings bindings) {
     String source = getScriptSource(variableScope);
+    source = preprocessScript(source, variableScope);
     try {
       return scriptEngine.eval(source, bindings);
     }

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/ExecutableScript.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/ExecutableScript.java
@@ -23,7 +23,12 @@ import org.finos.fluxnova.bpm.engine.ProcessEngineException;
 import org.finos.fluxnova.bpm.engine.delegate.DelegateCaseExecution;
 import org.finos.fluxnova.bpm.engine.delegate.DelegateExecution;
 import org.finos.fluxnova.bpm.engine.delegate.VariableScope;
+import org.finos.fluxnova.bpm.engine.impl.ProcessEngineLogger;
+import org.finos.fluxnova.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.finos.fluxnova.bpm.engine.impl.context.Context;
 import org.finos.fluxnova.bpm.engine.impl.persistence.entity.TaskEntity;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
 
 /**
  * <p>Represents an executable script.</p>
@@ -33,6 +38,8 @@ import org.finos.fluxnova.bpm.engine.impl.persistence.entity.TaskEntity;
  *
  */
 public abstract class ExecutableScript {
+
+  private static final ScriptLogger LOG = ProcessEngineLogger.SCRIPT_LOGGER;
 
   /** The language of the script. Used to resolve the
    * {@link ScriptEngine}. */
@@ -94,4 +101,60 @@ public abstract class ExecutableScript {
 
   protected abstract Object evaluate(ScriptEngine scriptEngine, VariableScope variableScope, Bindings bindings);
 
+  /**
+   * Preprocesses a script before execution.
+   *
+   * <p>If script preprocessing is disabled, no preprocessor is configured, or the preprocessor
+   * returns {@code null}, the original script is returned unchanged.</p>
+   *
+   * <p>If preprocessing fails with an exception, a warning is logged and the original script is
+   * returned as a safe fallback to ensure scripts continue to execute.</p>
+   *
+   * @param script the script text to preprocess; may be {@code null}
+   * @param variableScope the current execution context; may be {@code null}
+   * @return the preprocessed script, or the original script if preprocessing is disabled,
+   *         not configured, returns {@code null}, or fails with an exception
+   */
+  protected String preprocessScript(String script, VariableScope variableScope) {
+    if (script == null) {
+      return script;
+    }
+
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    if (processEngineConfiguration == null
+        || !processEngineConfiguration.isEnableScriptPreprocessing()) {
+      return script;
+    }
+
+    ScriptPreprocessor scriptPreprocessor = processEngineConfiguration.getEffectiveScriptPreprocessor();
+    if (scriptPreprocessor == null) {
+      return script;
+    }
+
+    String preprocessorName = getPreprocessorName(scriptPreprocessor);
+
+    ScriptPreprocessorRequest request = new ScriptPreprocessorRequest(script, language, variableScope);
+    String processedScript;
+    try {
+      processedScript = scriptPreprocessor.process(request);
+    } catch (Throwable e) {
+      LOG.warnScriptPreprocessingFailed(language, preprocessorName, e);
+      return script;
+    }
+
+    if (processedScript == null) {
+      return script;
+    }
+
+    return processedScript;
+  }
+
+  private String getPreprocessorName(ScriptPreprocessor scriptPreprocessor) {
+    try {
+      String name = scriptPreprocessor.getName();
+      return name != null ? name : "<unknown>";
+    } catch (Exception e) {
+      return "<unknown>";
+    }
+  }
 }

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/ScriptFactory.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/ScriptFactory.java
@@ -19,10 +19,16 @@ package org.finos.fluxnova.bpm.engine.impl.scripting;
 import org.finos.fluxnova.bpm.engine.delegate.Expression;
 
 /**
- * <p>A script factory is responsible for creating a {@link ExecutableScript}
- * instance. Users may customize (subclass) this class in order to customize script
- * creation. For instance, some users may choose to pre-process scripts before
- * they are created.</p>
+ * <p>A script factory is responsible for creating {@link ExecutableScript}
+ * instances. Users may customize (subclass) this class in order to customize script
+ * creation.</p>
+ *
+ * <p>The default executable script implementations created by this factory preserve
+ * configured script preprocessing behavior automatically. Custom subclasses that
+ * return their own {@link ExecutableScript} implementations should ensure that
+ * configured script preprocessors are still applied before evaluation if they
+ * want those custom implementations to participate in the script preprocessing
+ * feature.</p>
  *
  * @author Daniel Meyer
  *

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/ScriptLogger.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/ScriptLogger.java
@@ -39,4 +39,24 @@ public class ScriptLogger extends ProcessEngineLogger {
         "001", "Evaluating non-compiled script {}", scriptSource);
   }
 
+  public void warnScriptPreprocessorRequestNull(String preprocessorName) {
+    logWarn(
+        "004",
+        "ScriptPreprocessorRequest is null in preprocessor {}; returning null (no preprocessing will be done).",
+        preprocessorName);
+  }
+
+  public void warnScriptPreprocessingFailed(
+      String language,
+      String preprocessorName,
+      Throwable throwable) {
+    logWarn(
+        "005",
+        "Script preprocessing failed for language {} using preprocessor {}. Error: {}. Falling back to the original script.",
+        language,
+        preprocessorName,
+        throwable.getMessage(),
+        throwable);
+  }
+
 }

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/SourceExecutableScript.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/SourceExecutableScript.java
@@ -16,12 +16,15 @@
  */
 package org.finos.fluxnova.bpm.engine.impl.scripting;
 
+import java.util.Objects;
+
 import javax.script.Bindings;
 import javax.script.Compilable;
 import javax.script.CompiledScript;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.finos.fluxnova.bpm.engine.ScriptCompilationException;
 import org.finos.fluxnova.bpm.engine.ScriptEvaluationException;
 import org.finos.fluxnova.bpm.engine.delegate.BpmnError;
@@ -44,7 +47,12 @@ public class SourceExecutableScript extends CompiledExecutableScript {
   protected String scriptSource;
 
   /** Flag to signal if the script should be compiled */
-  protected boolean shouldBeCompiled = true;
+  protected volatile boolean shouldBeCompiled = true;
+
+  /** Digest of the processed script source used to produce the current {@link #compiledScript}.
+   * A {@code null} value indicates no compiled artifact is present.
+   */
+  protected volatile String compiledScriptSourceDigest;
 
   public SourceExecutableScript(String language, String source) {
     super(language);
@@ -53,16 +61,34 @@ public class SourceExecutableScript extends CompiledExecutableScript {
 
   @Override
   public Object evaluate(ScriptEngine engine, VariableScope variableScope, Bindings bindings) {
-    if (shouldBeCompiled) {
-      compileScript(engine);
+    String processedScript = preprocessScript(scriptSource, variableScope);
+    String processedScriptDigest = null;
+    CompiledScript compiledScriptToEvaluate;
+
+    synchronized (this) {
+      boolean hasCompiledScript = compiledScript != null;
+
+      if (hasCompiledScript || shouldBeCompiled) {
+        processedScriptDigest = computeScriptDigest(processedScript);
+      }
+
+      if (hasCompiledScript && !Objects.equals(compiledScriptSourceDigest, processedScriptDigest)) {
+        invalidateCompiledScript();
+      }
+
+      if (shouldBeCompiled) {
+        compileScript(engine, processedScript);
+      }
+
+      compiledScriptToEvaluate = compiledScript;
     }
 
-    if (getCompiledScript() != null) {
-      return super.evaluate(engine, variableScope, bindings);
+    if (compiledScriptToEvaluate != null) {
+      return evaluateCompiledScript(compiledScriptToEvaluate, variableScope, bindings);
     }
     else {
       try {
-        return evaluateScript(engine, bindings);
+        return evaluateScript(engine, processedScript, bindings);
       } catch (ScriptException e) {
         if (e.getCause() instanceof BpmnError) {
           throw (BpmnError) e.getCause();
@@ -73,7 +99,7 @@ public class SourceExecutableScript extends CompiledExecutableScript {
     }
   }
 
-  protected void compileScript(ScriptEngine engine) {
+  protected void compileScript(ScriptEngine engine, String processedScript) {
     ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
     if (processEngineConfiguration.isEnableScriptEngineCaching() && processEngineConfiguration.isEnableScriptCompilation()) {
 
@@ -81,7 +107,8 @@ public class SourceExecutableScript extends CompiledExecutableScript {
         synchronized (this) {
           if (getCompiledScript() == null && shouldBeCompiled) {
             // try to compile script
-            compiledScript = compile(engine, language, scriptSource);
+            compiledScript = compile(engine, language, processedScript);
+            compiledScriptSourceDigest = compiledScript != null ? computeScriptDigest(processedScript) : null;
 
             // either the script was successfully compiled or it can't be
             // compiled but we won't try it again
@@ -120,9 +147,9 @@ public class SourceExecutableScript extends CompiledExecutableScript {
 
   }
 
-  protected Object evaluateScript(ScriptEngine engine, Bindings bindings) throws ScriptException {
-    LOG.debugEvaluatingNonCompiledScript(scriptSource);
-    return engine.eval(scriptSource, bindings);
+  protected Object evaluateScript(ScriptEngine engine, String processedScript, Bindings bindings) throws ScriptException {
+    LOG.debugEvaluatingNonCompiledScript(processedScript);
+    return engine.eval(processedScript, bindings);
   }
 
   public String getScriptSource() {
@@ -135,14 +162,38 @@ public class SourceExecutableScript extends CompiledExecutableScript {
    * @param scriptSource
    *          the new script source code
    */
-  public void setScriptSource(String scriptSource) {
-    this.compiledScript = null;
-    shouldBeCompiled = true;
+  public synchronized void setScriptSource(String scriptSource) {
+    invalidateCompiledScript();
     this.scriptSource = scriptSource;
+  }
+
+  /**
+   * Invalidates all cached compilation state for this script instance.
+   *
+   * <p>This method clears the currently cached compiled artifact and its
+   * associated source digest, and marks the script as eligible for compilation
+   * on the next evaluation. The method is synchronized to guarantee that cache
+   * reset is applied atomically with respect to concurrent evaluation and source
+   * updates.</p>
+   */
+  protected synchronized void invalidateCompiledScript() {
+    this.compiledScript = null;
+    this.compiledScriptSourceDigest = null;
+    this.shouldBeCompiled = true;
   }
 
   public boolean isShouldBeCompiled() {
     return shouldBeCompiled;
+  }
+
+  /**
+   * Computes a collision-resistant SHA-256 digest of the given script text.
+   *
+   * @param scriptText the script text to digest
+   * @return the hex-encoded SHA-256 digest, or {@code null} if {@code scriptText} is {@code null}
+   */
+  private String computeScriptDigest(String scriptText) {
+    return scriptText != null ? DigestUtils.sha256Hex(scriptText) : null;
   }
 
 }

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/preprocessor/CompositeScriptPreprocessor.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/preprocessor/CompositeScriptPreprocessor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.finos.fluxnova.bpm.engine.impl.ProcessEngineLogger;
+import org.finos.fluxnova.bpm.engine.impl.scripting.ScriptLogger;
+
+/**
+ * Composite {@link ScriptPreprocessor} that applies configured preprocessors sequentially.
+ */
+public class CompositeScriptPreprocessor implements ScriptPreprocessor {
+
+  private static final ScriptLogger LOG = ProcessEngineLogger.SCRIPT_LOGGER;
+
+  private final List<ScriptPreprocessor> preprocessors;
+
+  /**
+   * Creates a composite preprocessor from the given preprocessors.
+   * Null entries are ignored.
+   *
+   * @param preprocessors preprocessors to apply in order; may be {@code null}
+   */
+  public CompositeScriptPreprocessor(List<ScriptPreprocessor> preprocessors) {
+    if (preprocessors == null) {
+      this.preprocessors = Collections.unmodifiableList(new ArrayList<>());
+    } else {
+      this.preprocessors = preprocessors.stream()
+          .filter(Objects::nonNull)
+          .toList();
+    }
+  }
+
+  /**
+   * Applies each configured preprocessor in sequence.
+   *
+   * <p>If {@code request} is {@code null}, this method logs a warning and returns {@code null}.</p>
+   *
+   * <p>If {@code request.getScript()} is {@code null}, this method returns {@code null} immediately.
+   * Empty scripts are valid input and are passed through the configured preprocessor chain.</p>
+   *
+   * @param request current preprocessing request
+   * @return {@code null} when the request itself is {@code null} or its script is {@code null};
+   *         otherwise the original script or the latest non-{@code null} processed script
+   */
+  @Override
+  public String process(ScriptPreprocessorRequest request) {
+    if (request == null) {
+      LOG.warnScriptPreprocessorRequestNull(getName());
+      return null;
+    }
+    String script = request.getScript();
+    if (script == null) {
+      return script;
+    }
+    for (ScriptPreprocessor preprocessor : preprocessors) {
+      ScriptPreprocessorRequest nextRequest = new ScriptPreprocessorRequest(script, request.getLanguage(), request.getVariableScope());
+      String processedScript = preprocessor.process(nextRequest);
+      if (processedScript == null) {
+        continue;
+      }
+      script = processedScript;
+    }
+    return script;
+  }
+
+  /**
+   * @return the configured preprocessors in execution order
+   */
+  public List<ScriptPreprocessor> getPreprocessors() {
+    return preprocessors;
+  }
+
+  /**
+   * Returns the human-readable name of this preprocessor.
+   *
+   * @return the preprocessor name
+   */
+  @Override
+  public String getName() {
+    return "CompositeScriptPreprocessor";
+  }
+}

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/preprocessor/ScriptPreprocessor.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/preprocessor/ScriptPreprocessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor;
+
+/**
+ * SPI for preprocessing scripts before they are evaluated by a script engine.
+ */
+public interface ScriptPreprocessor {
+
+  /**
+   * Preprocesses the script before execution.
+   *
+   * @param request encapsulates script text and execution context
+   * @return processed script text; returning {@code null} indicates no replacement and lets
+   *         the caller continue with the original script
+   */
+  String process(ScriptPreprocessorRequest request);
+
+  /**
+   * Returns a stable, human-readable name for this preprocessor implementation.
+   *
+   * @return the preprocessor name
+   */
+  String getName();
+}

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/preprocessor/ScriptPreprocessorRequest.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/preprocessor/ScriptPreprocessorRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor;
+
+import org.finos.fluxnova.bpm.engine.delegate.VariableScope;
+
+/**
+ * Immutable request object passed to a {@link ScriptPreprocessor}.
+ * It contains the current script content together with execution context metadata.
+ */
+public final class ScriptPreprocessorRequest {
+
+  private final String script;
+  private final String language;
+  private final VariableScope variableScope;
+
+  /**
+   * Creates a preprocessing request.
+   *
+   * @param script the current script content; may be {@code null}
+   * @param language the script language; may be {@code null}
+   * @param variableScope the current variable scope; may be {@code null}
+   */
+  public ScriptPreprocessorRequest(String script, String language, VariableScope variableScope) {
+    this.script = script;
+    this.language = language;
+    this.variableScope = variableScope;
+  }
+
+  /**
+   * @return the current script content, or {@code null} if none is available
+   */
+  public String getScript() {
+    return script;
+  }
+
+  /**
+   * @return the script language, or {@code null} if unknown
+   */
+  public String getLanguage() {
+    return language;
+  }
+
+  /**
+   * @return the current variable scope, or {@code null} if no scope is associated
+   */
+  public VariableScope getVariableScope() {
+    return variableScope;
+  }
+}

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationScriptPreprocessorTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/cfg/ProcessEngineConfigurationScriptPreprocessorTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.bpm.engine.impl.cfg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.finos.fluxnova.bpm.engine.ProcessEngineConfiguration;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.CompositeScriptPreprocessor;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for script preprocessor configuration in {@link ProcessEngineConfigurationImpl}.
+ *
+ * <p>Validates enabling/disabling preprocessing, setting and adding preprocessors, defensive copy
+ * semantics, cache invalidation on configuration changes, and effective preprocessor resolution
+ * (single instance vs. {@link CompositeScriptPreprocessor}).</p>
+ */
+public class ProcessEngineConfigurationScriptPreprocessorTest {
+
+  private ProcessEngineConfigurationImpl configuration;
+
+  @Before
+  public void setUp() {
+    configuration = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration
+        .createProcessEngineConfigurationFromResourceDefault();
+  }
+
+  // -------------------------------------------------------------------------
+  // Enable / disable flag
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void shouldBeDisabledByDefault() {
+    assertThat(configuration.isEnableScriptPreprocessing()).isFalse();
+  }
+
+  @Test
+  public void shouldEnableScriptPreprocessing() {
+    // when
+    configuration.setEnableScriptPreprocessing(true);
+
+    // then
+    assertThat(configuration.isEnableScriptPreprocessing()).isTrue();
+  }
+
+  @Test
+  public void shouldDisableScriptPreprocessingAgain() {
+    // given
+    configuration.setEnableScriptPreprocessing(true);
+
+    // when
+    configuration.setEnableScriptPreprocessing(false);
+
+    // then
+    assertThat(configuration.isEnableScriptPreprocessing()).isFalse();
+  }
+
+  // -------------------------------------------------------------------------
+  // getEffectiveScriptPreprocessor — disabled / no preprocessors
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void shouldReturnNullEffectivePreprocessorWhenDisabled() {
+    // given
+    configuration.setEnableScriptPreprocessing(false);
+    configuration.setScriptPreprocessors(Collections.singletonList(mockPreprocessor("p1")));
+
+    // when / then
+    assertThat(configuration.getEffectiveScriptPreprocessor()).isNull();
+  }
+
+  @Test
+  public void shouldReturnNullEffectivePreprocessorWhenNoPreprocessorsConfigured() {
+    // given
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.setScriptPreprocessors(null);
+
+    // when / then
+    assertThat(configuration.getEffectiveScriptPreprocessor()).isNull();
+  }
+
+  @Test
+  public void shouldReturnNullEffectivePreprocessorWhenEmptyListConfigured() {
+    // given
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.setScriptPreprocessors(Collections.emptyList());
+
+    // when / then
+    assertThat(configuration.getEffectiveScriptPreprocessor()).isNull();
+  }
+
+  // -------------------------------------------------------------------------
+  // getEffectiveScriptPreprocessor — single vs composite resolution
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void shouldReturnSinglePreprocessorDirectlyWhenOnlyOneConfigured() {
+    // given
+    ScriptPreprocessor preprocessor = mockPreprocessor("only");
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.setScriptPreprocessors(Collections.singletonList(preprocessor));
+
+    // when
+    ScriptPreprocessor effective = configuration.getEffectiveScriptPreprocessor();
+
+    // then
+    assertThat(effective).isSameAs(preprocessor);
+  }
+
+  @Test
+  public void shouldReturnCompositePreprocessorWhenMultipleConfigured() {
+    // given
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.setScriptPreprocessors(Arrays.asList(mockPreprocessor("p1"), mockPreprocessor("p2")));
+
+    // when
+    ScriptPreprocessor effective = configuration.getEffectiveScriptPreprocessor();
+
+    // then
+    assertThat(effective).isInstanceOf(CompositeScriptPreprocessor.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // Cache invalidation
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void shouldInvalidateCacheWhenPreprocessingDisabled() {
+    // given
+    ScriptPreprocessor preprocessor = mockPreprocessor("p1");
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.setScriptPreprocessors(Collections.singletonList(preprocessor));
+    ScriptPreprocessor before = configuration.getEffectiveScriptPreprocessor();
+    assertThat(before).isNotNull();
+
+    // when
+    configuration.setEnableScriptPreprocessing(false);
+
+    // then
+    assertThat(configuration.getEffectiveScriptPreprocessor()).isNull();
+  }
+
+  @Test
+  public void shouldInvalidateCacheWhenPreprocessorsReplaced() {
+    // given
+    ScriptPreprocessor first = mockPreprocessor("first");
+    ScriptPreprocessor second = mockPreprocessor("second");
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.setScriptPreprocessors(Collections.singletonList(first));
+    ScriptPreprocessor before = configuration.getEffectiveScriptPreprocessor();
+    assertThat(before).isSameAs(first);
+
+    // when
+    configuration.setScriptPreprocessors(Collections.singletonList(second));
+
+    // then
+    assertThat(configuration.getEffectiveScriptPreprocessor()).isSameAs(second);
+  }
+
+  // -------------------------------------------------------------------------
+  // addScriptPreprocessor
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void shouldAddScriptPreprocessor() {
+    // given
+    ScriptPreprocessor preprocessor = mockPreprocessor("p1");
+
+    // when
+    configuration.addScriptPreprocessor(preprocessor);
+
+    // then
+    List<ScriptPreprocessor> preprocessors = configuration.getScriptPreprocessors();
+    assertThat(preprocessors).containsExactly(preprocessor);
+  }
+
+  @Test
+  public void shouldIgnoreNullOnAddScriptPreprocessor() {
+    // when
+    configuration.addScriptPreprocessor(null);
+
+    // then
+    assertThat(configuration.getScriptPreprocessors()).isNullOrEmpty();
+  }
+
+  @Test
+  public void shouldInvalidateCacheOnAddScriptPreprocessor() {
+    // given
+    ScriptPreprocessor first = mockPreprocessor("first");
+    ScriptPreprocessor second = mockPreprocessor("second");
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.setScriptPreprocessors(Collections.singletonList(first));
+    ScriptPreprocessor before = configuration.getEffectiveScriptPreprocessor();
+    assertThat(before).isSameAs(first);
+
+    // when
+    configuration.addScriptPreprocessor(second);
+
+    // then — two preprocessors now, so composite is returned
+    assertThat(configuration.getEffectiveScriptPreprocessor()).isInstanceOf(CompositeScriptPreprocessor.class);
+  }
+
+  // -------------------------------------------------------------------------
+  // getScriptPreprocessors — copy
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void shouldReturnDefensiveCopyOfPreprocessors() {
+    // given
+    configuration.setScriptPreprocessors(Collections.singletonList(mockPreprocessor("p1")));
+
+    // when
+    List<ScriptPreprocessor> copy = configuration.getScriptPreprocessors();
+    copy.clear();
+
+    // then — internal list not affected
+    assertThat(configuration.getScriptPreprocessors()).hasSize(1);
+  }
+
+  // -------------------------------------------------------------------------
+  // Test helpers — creates minimal mock preprocessors for use in test setup
+  // -------------------------------------------------------------------------
+
+  private ScriptPreprocessor mockPreprocessor(String name) {
+    ScriptPreprocessor p = mock(ScriptPreprocessor.class);
+    when(p.getName()).thenReturn(name);
+    when(p.process(any(ScriptPreprocessorRequest.class))).thenReturn(null);
+    return p;
+  }
+}

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/scripting/preprocessor/CompositeScriptPreprocessorTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/scripting/preprocessor/CompositeScriptPreprocessorTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link CompositeScriptPreprocessor}.
+ *
+ * <p>Validates the sequential chaining behavior of the composite preprocessor,
+ * including correct execution order, {@code null} return semantics (skip and continue),
+ * null-entry filtering in the constructor, and guard conditions for null requests
+ * and null scripts.</p>
+ */
+public class CompositeScriptPreprocessorTest {
+
+  @Test
+  public void shouldApplyPreprocessorsInOrder() {
+    // given
+    ScriptPreprocessor first = scriptPreprocessor("first", request -> request.getScript() + "-first");
+    ScriptPreprocessor second = scriptPreprocessor("second", request -> request.getScript() + "-second");
+
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(Arrays.asList(first, second));
+
+    // when
+    String processed = composite.process(new ScriptPreprocessorRequest("source", "groovy", null));
+
+    // then
+    assertThat(processed).isEqualTo("source-first-second");
+  }
+
+  @Test
+  public void shouldContinueWhenPreprocessorReturnsNull() {
+    // given
+    ScriptPreprocessor first = scriptPreprocessor("first", request -> null);
+    ScriptPreprocessor second = scriptPreprocessor("second", request -> request.getScript() + "-processed");
+
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(Arrays.asList(first, second));
+
+    // when
+    String processed = composite.process(new ScriptPreprocessorRequest("source", "groovy", null));
+
+    // then
+    assertThat(processed).isEqualTo("source-processed");
+  }
+
+  @Test
+  public void shouldIgnoreNullPreprocessorsInConstructor() {
+    // given
+    ScriptPreprocessor nonNull = scriptPreprocessor("only", request -> request.getScript() + "-ok");
+
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(Arrays.asList(null, nonNull, null));
+
+    // when
+    String processed = composite.process(new ScriptPreprocessorRequest("source", "groovy", null));
+
+    // then
+    assertThat(processed).isEqualTo("source-ok");
+    assertThat(composite.getPreprocessors()).hasSize(1);
+  }
+
+  @Test
+  public void shouldReturnNullWhenRequestIsNull() {
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(null);
+
+    assertThat(composite.process(null)).isNull();
+  }
+
+  @Test
+  public void shouldReturnNullWhenScriptIsNull() {
+    // given
+    AtomicBoolean called = new AtomicBoolean(false);
+    ScriptPreprocessor preprocessor = scriptPreprocessor("probe", request -> {
+      called.set(true);
+      return request.getScript() + "-changed";
+    });
+
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(Collections.singletonList(preprocessor));
+
+    // when
+    String result = composite.process(new ScriptPreprocessorRequest(null, "groovy", null));
+
+    // then
+    assertThat(result).isNull();
+    assertThat(called).isFalse();
+  }
+
+  @Test
+  public void shouldProcessEmptyScript() {
+    // given
+    ScriptPreprocessor preprocessor = scriptPreprocessor("probe", request -> request.getScript() + "-changed");
+
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(Collections.singletonList(preprocessor));
+
+    // when
+    String result = composite.process(new ScriptPreprocessorRequest("", "groovy", null));
+
+    // then
+    assertThat(result).isEqualTo("-changed");
+  }
+
+  @Test
+  public void shouldExposeCompositeName() {
+    CompositeScriptPreprocessor composite = new CompositeScriptPreprocessor(null);
+
+    assertThat(composite.getName()).isEqualTo("CompositeScriptPreprocessor");
+  }
+
+  private ScriptPreprocessor scriptPreprocessor(String name, Function<ScriptPreprocessorRequest, String> behavior) {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return behavior.apply(request);
+      }
+
+      @Override
+      public String getName() {
+        return name;
+      }
+    };
+  }
+}

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/scripting/preprocessor/ScriptPreprocessorRequestTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/scripting/preprocessor/ScriptPreprocessorRequestTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.finos.fluxnova.bpm.engine.delegate.VariableScope;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ScriptPreprocessorRequest}
+ *
+ * <p>Validates that the request object correctly stores and retrieves script content,
+ * language, and variable scope metadata. Tests cover all nullability scenarios to ensure
+ * the Class handles optional fields as documented in the SPI contract.</p>
+ */
+public class ScriptPreprocessorRequestTest {
+
+  @Test
+  public void shouldConstructWithAllParameters() {
+    // given
+    String script = "var x = 1;";
+    String language = "javascript";
+    VariableScope variableScope = mock(VariableScope.class);
+
+    // when
+    ScriptPreprocessorRequest request = new ScriptPreprocessorRequest(script, language, variableScope);
+
+    // then
+    assertThat(request.getScript()).isEqualTo(script);
+    assertThat(request.getLanguage()).isEqualTo(language);
+    assertThat(request.getVariableScope()).isEqualTo(variableScope);
+  }
+
+  @Test
+  public void shouldConstructWithNullScript() {
+    // given
+    String language = "javascript";
+    VariableScope variableScope = mock(VariableScope.class);
+
+    // when
+    ScriptPreprocessorRequest request = new ScriptPreprocessorRequest(null, language, variableScope);
+
+    // then
+    assertThat(request.getScript()).isNull();
+    assertThat(request.getLanguage()).isEqualTo(language);
+    assertThat(request.getVariableScope()).isEqualTo(variableScope);
+  }
+
+  @Test
+  public void shouldConstructWithNullLanguage() {
+    // given
+    String script = "var x = 1;";
+    VariableScope variableScope = mock(VariableScope.class);
+
+    // when
+    ScriptPreprocessorRequest request = new ScriptPreprocessorRequest(script, null, variableScope);
+
+    // then
+    assertThat(request.getScript()).isEqualTo(script);
+    assertThat(request.getLanguage()).isNull();
+    assertThat(request.getVariableScope()).isEqualTo(variableScope);
+  }
+
+  @Test
+  public void shouldConstructWithNullVariableScope() {
+    // given
+    String script = "var x = 1;";
+    String language = "javascript";
+
+    // when
+    ScriptPreprocessorRequest request = new ScriptPreprocessorRequest(script, language, null);
+
+    // then
+    assertThat(request.getScript()).isEqualTo(script);
+    assertThat(request.getLanguage()).isEqualTo(language);
+    assertThat(request.getVariableScope()).isNull();
+  }
+
+  @Test
+  public void shouldConstructWithAllNullFields() {
+    // when
+    ScriptPreprocessorRequest request = new ScriptPreprocessorRequest(null, null, null);
+
+    // then
+    assertThat(request.getScript()).isNull();
+    assertThat(request.getLanguage()).isNull();
+    assertThat(request.getVariableScope()).isNull();
+  }
+
+  @Test
+  public void shouldReturnEmptyScriptAsIs() {
+    // given
+    String emptyScript = "";
+    String language = "groovy";
+
+    // when
+    ScriptPreprocessorRequest request = new ScriptPreprocessorRequest(emptyScript, language, null);
+
+    // then
+    assertThat(request.getScript()).isEmpty();
+    assertThat(request.getScript()).isEqualTo("");
+  }
+}

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/test/standalone/scripting/ScriptCompilationTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/test/standalone/scripting/ScriptCompilationTest.java
@@ -16,10 +16,27 @@
  */
 package org.finos.fluxnova.bpm.engine.test.standalone.scripting;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.script.CompiledScript;
+import javax.script.ScriptEngine;
 
 import org.finos.fluxnova.bpm.engine.impl.interceptor.Command;
 import org.finos.fluxnova.bpm.engine.impl.interceptor.CommandContext;
@@ -27,6 +44,8 @@ import org.finos.fluxnova.bpm.engine.impl.scripting.ExecutableScript;
 import org.finos.fluxnova.bpm.engine.impl.scripting.ScriptFactory;
 import org.finos.fluxnova.bpm.engine.impl.scripting.SourceExecutableScript;
 import org.finos.fluxnova.bpm.engine.impl.scripting.env.ScriptingEnvironment;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
 import org.finos.fluxnova.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -136,6 +155,235 @@ public class ScriptCompilationTest extends PluggableProcessEngineTest {
     // it is compiled again
     assertFalse(script.isShouldBeCompiled());
     assertNotNull(script.getCompiledScript());
+  }
+
+  @Test
+  public void testRecompileWhenPreprocessedScriptChanges() {
+    // given
+    boolean preprocessingEnabledBefore = processEngineConfiguration.isEnableScriptPreprocessing();
+    List<ScriptPreprocessor> preprocessorsBefore = processEngineConfiguration.getScriptPreprocessors();
+
+    // preprocessor returns a different script on each invocation to simulate changing output
+    AtomicInteger preprocessorInvocations = new AtomicInteger();
+    ScriptPreprocessor preprocessor = new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return preprocessorInvocations.incrementAndGet() == 1 ? "1 + 1" : "1 + 2";
+      }
+
+      @Override
+      public String getName() {
+        return "changing-preprocessor";
+      }
+    };
+    enablePreprocessingWith(preprocessor);
+
+    // source is a placeholder; the registered preprocessor replaces it entirely at runtime
+    AtomicInteger compileInvocations = new AtomicInteger();
+    SourceExecutableScript script = createCountingScript(compileInvocations);
+
+    try {
+      // when
+      Object firstResult = executeScript(script);
+      CompiledScript compiledForFirstPreprocessedOutput = script.getCompiledScript();
+      
+      Object secondResult = executeScript(script);
+      CompiledScript compiledForSecondPreprocessedOutput = script.getCompiledScript();
+
+      // then — each execution evaluates a distinct preprocessed script
+      assertEquals(2, firstResult);
+      assertEquals(3, secondResult);
+
+      // compile() is called exactly twice — once per unique preprocessed output,
+      // confirming that the compiled cache is invalidated and recompilation is triggered
+      // when the preprocessor returns different output on subsequent executions
+      assertEquals("compile() should be called once per unique preprocessed script",
+          2, compileInvocations.get());
+      assertNotNull(compiledForFirstPreprocessedOutput);
+      assertNotNull(compiledForSecondPreprocessedOutput);
+      assertNotSame("compiled scripts for different preprocessed outputs must not be reused",
+          compiledForFirstPreprocessedOutput, compiledForSecondPreprocessedOutput);
+    } finally {
+      restorePreprocessingConfig(preprocessingEnabledBefore, preprocessorsBefore);
+    }
+  }
+
+  @Test
+  public void testCompiledScriptCacheIsReusedWhenPreprocessedScriptIsStable() {
+    // given — a preprocessor that consistently returns the same script on every invocation
+    boolean preprocessingEnabledBefore = processEngineConfiguration.isEnableScriptPreprocessing();
+    List<ScriptPreprocessor> preprocessorsBefore = processEngineConfiguration.getScriptPreprocessors();
+
+    ScriptPreprocessor preprocessor = new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return "1 + 1";
+      }
+
+      @Override
+      public String getName() {
+        return "stable-preprocessor";
+      }
+    };
+    enablePreprocessingWith(preprocessor);
+
+    // source is a placeholder; the registered preprocessor replaces it entirely at runtime
+    AtomicInteger compileInvocations = new AtomicInteger();
+    SourceExecutableScript script = createCountingScript(compileInvocations);
+
+    try {
+      // when — executed three times with identical preprocessed output
+      Object firstResult = executeScript(script);
+      Object secondResult = executeScript(script);
+      Object thirdResult = executeScript(script);
+
+      // then — all executions produce the correct result
+      assertEquals(2, firstResult);
+      assertEquals(2, secondResult);
+      assertEquals(2, thirdResult);
+
+      // compile() is called exactly once — confirming the compiled artifact is reused
+      // on the second and third executions rather than recompiled from the same source
+      assertEquals("compile() should be called exactly once; subsequent executions must reuse the cached artifact",
+          1, compileInvocations.get());
+    } finally {
+      restorePreprocessingConfig(preprocessingEnabledBefore, preprocessorsBefore);
+    }
+  }
+
+  @Test
+  public void testRecompileWhenPreprocessedScriptChangesConcurrently() throws Exception {
+    // given
+    boolean preprocessingEnabledBefore = processEngineConfiguration.isEnableScriptPreprocessing();
+    List<ScriptPreprocessor> preprocessorsBefore = processEngineConfiguration.getScriptPreprocessors();
+
+    AtomicInteger preprocessorInvocations = new AtomicInteger();
+    ScriptPreprocessor preprocessor = new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return preprocessorInvocations.incrementAndGet() % 2 == 0 ? "1 + 2" : "1 + 1";
+      }
+
+      @Override
+      public String getName() {
+        return "alternating-preprocessor";
+      }
+    };
+    enablePreprocessingWith(preprocessor);
+
+    AtomicInteger compileInvocations = new AtomicInteger();
+    SourceExecutableScript script = createCountingScript(compileInvocations);
+
+    int threadCount = 8;
+    int iterationsPerThread = 25;
+    int totalExecutions = threadCount * iterationsPerThread;
+    CountDownLatch startGate = new CountDownLatch(1);
+    Set<Integer> observedResults = ConcurrentHashMap.newKeySet();
+
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    try {
+      List<Future<?>> futures = new java.util.ArrayList<>(threadCount);
+      for (int i = 0; i < threadCount; i++) {
+        futures.add(executor.submit(() -> {
+          startGate.await();
+          for (int j = 0; j < iterationsPerThread; j++) {
+            Object value = executeScript(script);
+            observedResults.add((Integer) value);
+          }
+          return null;
+        }));
+      }
+
+      // when
+      startGate.countDown();
+      for (Future<?> future : futures) {
+        future.get(30, TimeUnit.SECONDS);
+      }
+
+      // then
+      assertEquals("preprocessor should run once per execution", totalExecutions, preprocessorInvocations.get());
+      assertTrue("result 2 should be observed", observedResults.contains(2));
+      assertTrue("result 3 should be observed", observedResults.contains(3));
+      assertTrue("compile() should run at least twice for alternating preprocessed output",
+          compileInvocations.get() >= 2);
+      assertTrue("compile() should not exceed execution count", compileInvocations.get() <= totalExecutions);
+
+      int compileCountAfterConcurrentPhase = compileInvocations.get();
+      enablePreprocessingWith(new ScriptPreprocessor() {
+        @Override
+        public String process(ScriptPreprocessorRequest request) {
+          return "1 + 1";
+        }
+
+        @Override
+        public String getName() {
+          return "stable-preprocessor-after-concurrency";
+        }
+      });
+
+      Object stableFirstResult = executeScript(script);
+      CompiledScript compiledAfterStableExecution = script.getCompiledScript();
+      Object stableSecondResult = executeScript(script);
+
+      assertEquals(2, stableFirstResult);
+      assertEquals(2, stableSecondResult);
+      assertNotNull(compiledAfterStableExecution);
+      assertSame("once preprocessing output stabilizes, the compiled artifact should be reused",
+          compiledAfterStableExecution, script.getCompiledScript());
+      assertTrue("stabilizing the preprocessing output should require at most one additional compilation",
+          compileInvocations.get() <= compileCountAfterConcurrentPhase + 1);
+    } finally {
+      executor.shutdownNow();
+      restorePreprocessingConfig(preprocessingEnabledBefore, preprocessorsBefore);
+    }
+  }
+
+  /**
+   * Creates a {@link SourceExecutableScript} instrumented subclass that increments
+   * {@code compileInvocations} on each call to {@link SourceExecutableScript#compile},
+   * enabling tests to assert the exact number of compilations and verify whether
+   * subsequent executions are served from the compiled cache or trigger recompilation.
+   *
+   * <p>The script source is set to a placeholder value. Tests using this method are
+   * expected to register a preprocessor via {@link #enablePreprocessingWith} that
+   * replaces the source entirely at runtime.</p>
+   *
+   * @param compileInvocations counter incremented on each compilation
+   * @return instrumented script instance backed by {@link #SCRIPT_LANGUAGE}
+   */
+  private SourceExecutableScript createCountingScript(AtomicInteger compileInvocations) {
+    return new SourceExecutableScript(SCRIPT_LANGUAGE, "ignored") {
+      @Override
+      public CompiledScript compile(ScriptEngine scriptEngine, String language, String src) {
+        compileInvocations.incrementAndGet();
+        return super.compile(scriptEngine, language, src);
+      }
+    };
+  }
+
+  /**
+   * Enables script preprocessing on the current engine configuration and registers
+   * the given preprocessor as the sole active preprocessor for the duration of the test.
+   * Any previously configured preprocessors are replaced.
+   *
+   * @param preprocessor the preprocessor to register; replaces any existing preprocessors
+   */
+  private void enablePreprocessingWith(ScriptPreprocessor preprocessor) {
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.setScriptPreprocessors(Collections.singletonList(preprocessor));
+  }
+
+  /**
+   * Restores script preprocessing configuration to the state captured before the test.
+   * Must be called from a {@code finally} block to guarantee restoration even when
+   * test assertions fail.
+   *
+   * @param enabledBefore       preprocessing flag value before the test
+   * @param preprocessorsBefore preprocessor list captured before the test
+   */
+  private void restorePreprocessingConfig(boolean enabledBefore, List<ScriptPreprocessor> preprocessorsBefore) {
+    processEngineConfiguration.setEnableScriptPreprocessing(enabledBefore);
+    processEngineConfiguration.setScriptPreprocessors(preprocessorsBefore);
   }
 
   protected Object executeScript(final ExecutableScript script) {

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/test/standalone/scripting/ScriptPreprocessingTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/test/standalone/scripting/ScriptPreprocessingTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.bpm.engine.test.standalone.scripting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.script.ScriptEngine;
+
+import org.finos.fluxnova.bpm.engine.ProcessEngine;
+import org.finos.fluxnova.bpm.engine.ProcessEngineConfiguration;
+import org.finos.fluxnova.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.finos.fluxnova.bpm.engine.impl.context.Context;
+import org.finos.fluxnova.bpm.engine.impl.scripting.ScriptFactory;
+import org.finos.fluxnova.bpm.engine.impl.scripting.SourceExecutableScript;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for the script preprocessing SPI within {@link SourceExecutableScript}.
+ *
+ * <p>Verifies that preprocessing is applied when enabled, bypassed when disabled,
+ * falls back to the original script when the preprocessor returns {@code null} or throws,
+ * and that multiple chained preprocessors are applied in order.</p>
+ *
+ * <p>These tests build a {@link ProcessEngine} from the default engine configuration in
+ * {@link #setUp()} and execute scripts through the normal {@code preprocessScript -> evaluate}
+ * path. This provides realistic engine-level coverage of preprocessing behavior without
+ * requiring dedicated integration-test container setup.</p>
+ */
+public class ScriptPreprocessingTest {
+
+  protected static final String SCRIPT_LANGUAGE = "groovy";
+  protected static final String ORIGINAL_SCRIPT = "1 + 1";
+  protected static final String PREPROCESSED_SCRIPT = "1 + 2";
+
+  protected ProcessEngineConfigurationImpl configuration;
+  protected ScriptFactory scriptFactory;
+  protected ProcessEngine processEngine;
+
+  @Before
+  public void setUp() {
+    processEngine = ProcessEngineConfiguration
+        .createProcessEngineConfigurationFromResourceDefault()
+        .buildProcessEngine();
+    configuration = (ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration();
+    scriptFactory = configuration.getScriptFactory();
+
+    configuration.setEnableScriptPreprocessing(false);
+    configuration.setScriptPreprocessors(null);
+
+    Context.setProcessEngineConfiguration(configuration);
+  }
+
+  @After
+  public void tearDown() {
+    configuration.setEnableScriptPreprocessing(false);
+    configuration.setScriptPreprocessors(null);
+    Context.removeProcessEngineConfiguration();
+    processEngine.close();
+  }
+
+  // -------------------------------------------------------------------------
+  // Preprocessing disabled (default)
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void shouldReturnOriginalScriptWhenPreprocessingDisabled() {
+    // given
+    AtomicReference<String> capturedScript = new AtomicReference<>();
+    configuration.setEnableScriptPreprocessing(false);
+    configuration.addScriptPreprocessor(capturingPreprocessor(capturedScript, PREPROCESSED_SCRIPT));
+
+    SourceExecutableScript script = createScript(ORIGINAL_SCRIPT);
+
+    // when
+    Object result = executeScript(script);
+
+    // then — preprocessing bypassed; original script evaluated
+    assertThat(capturedScript.get()).isNull();
+    assertThat(result).isEqualTo(2);
+  }
+
+  // -------------------------------------------------------------------------
+  // Preprocessing enabled
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void shouldApplyPreprocessorWhenEnabled() {
+    // given
+    AtomicReference<String> capturedScript = new AtomicReference<>();
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.addScriptPreprocessor(capturingPreprocessor(capturedScript, PREPROCESSED_SCRIPT));
+
+    SourceExecutableScript script = createScript(ORIGINAL_SCRIPT);
+
+    // when
+    Object result = executeScript(script);
+
+    // then — preprocessor called; modified script evaluated
+    assertThat(capturedScript.get()).isEqualTo(ORIGINAL_SCRIPT);
+    assertThat(result).isEqualTo(3);
+  }
+
+  @Test
+  public void shouldFallBackToOriginalScriptWhenPreprocessorReturnsNull() {
+    // given
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.addScriptPreprocessor(nullReturningPreprocessor());
+
+    SourceExecutableScript script = createScript(ORIGINAL_SCRIPT);
+
+    // when
+    Object result = executeScript(script);
+
+    // then — null return means no replacement; original script evaluated
+    assertThat(result).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldFallBackToOriginalScriptWhenPreprocessorThrows() {
+    // given
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.addScriptPreprocessor(throwingPreprocessor());
+
+    SourceExecutableScript script = createScript(ORIGINAL_SCRIPT);
+
+    // when
+    Object result = executeScript(script);
+
+    // then — exception swallowed; original script evaluated safely
+    assertThat(result).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldApplyPreprocessorsInOrderWhenMultipleConfigured() {
+    // given — first appends "-a"; second captures what it receives to verify ordering
+    AtomicReference<String> inputToSecond = new AtomicReference<>();
+    configuration.setEnableScriptPreprocessing(true);
+    configuration.addScriptPreprocessor(appendingPreprocessor("-a"));
+    configuration.addScriptPreprocessor(capturingPreprocessor(inputToSecond, PREPROCESSED_SCRIPT));
+
+    SourceExecutableScript script = createScript(ORIGINAL_SCRIPT);
+
+    // when
+    Object result = executeScript(script);
+
+    // then — second preprocessor received output of first
+    assertThat(inputToSecond.get()).isEqualTo("1 + 1-a");
+    assertThat(result).isEqualTo(3);
+  }
+
+  // -------------------------------------------------------------------------
+  // Test helpers
+  // -------------------------------------------------------------------------
+
+  protected SourceExecutableScript createScript(String source) {
+    return (SourceExecutableScript) scriptFactory.createScriptFromSource(SCRIPT_LANGUAGE, source);
+  }
+
+  protected Object executeScript(SourceExecutableScript script) {
+    ScriptEngine engine = configuration.getScriptingEngines().getScriptEngineForLanguage(SCRIPT_LANGUAGE);
+    return script.evaluate(engine, null, engine.createBindings());
+  }
+
+  private ScriptPreprocessor capturingPreprocessor(AtomicReference<String> capture, String output) {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        capture.set(request.getScript());
+        return output;
+      }
+
+      @Override
+      public String getName() {
+        return "capturingPreprocessor";
+      }
+    };
+  }
+
+  private ScriptPreprocessor nullReturningPreprocessor() {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return null;
+      }
+
+      @Override
+      public String getName() {
+        return "nullReturningPreprocessor";
+      }
+    };
+  }
+
+  private ScriptPreprocessor throwingPreprocessor() {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        throw new RuntimeException("Simulated preprocessing failure");
+      }
+
+      @Override
+      public String getName() {
+        return "throwingPreprocessor";
+      }
+    };
+  }
+
+  private ScriptPreprocessor appendingPreprocessor(String suffix) {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return request.getScript() + suffix;
+      }
+
+      @Override
+      public String getName() {
+        return "appendingPreprocessor[" + suffix + "]";
+      }
+    };
+  }
+}

--- a/qa/integration-tests-engine/src/test/java/org/finos/fluxnova/bpm/integrationtest/functional/scriptengine/ScriptPreprocessingCompilationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/finos/fluxnova/bpm/integrationtest/functional/scriptengine/ScriptPreprocessingCompilationTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.bpm.integrationtest.functional.scriptengine;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+
+import org.finos.fluxnova.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.finos.fluxnova.bpm.model.bpmn.Bpmn;
+import org.finos.fluxnova.bpm.model.bpmn.BpmnModelInstance;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Integration tests for script preprocessing and script compilation interactions in BPMN
+ * script tasks.
+ *
+ * <p>This suite validates observable runtime behavior across the full preprocessing/compilation
+ * flag matrix and key preprocessing edge cases. Each test executes an actual BPMN process model
+ * in the container-managed engine and asserts process variables, rather than asserting internal
+ * engine objects.</p>
+ *
+ * <p>Coverage includes:</p>
+ * <ul>
+ *   <li>preprocessing enabled/disabled with compilation enabled,</li>
+ *   <li>preprocessing enabled/disabled with compilation disabled,</li>
+ *   <li>ordered application of chained preprocessors,</li>
+ *   <li>fallback when a preprocessor returns {@code null}, and</li>
+ *   <li>behavior with an explicitly empty preprocessor list.</li>
+ * </ul>
+ *
+ * <p>Variable-binding-specific scenarios are covered in
+ * {@link ScriptPreprocessorIntegrationTest}.</p>
+ */
+@RunWith(Arquillian.class)
+public class ScriptPreprocessingCompilationTest extends AbstractFoxPlatformIntegrationTest {
+
+  /** Process definition key for the model deployed by this test class. */
+  private static final String PROCESS_KEY = "scriptPreprocessingCompilationProcess";
+  /** Script language configured for the BPMN script task. */
+  private static final String SCRIPT_LANG = "groovy";
+  /** Variable used by all tests to read script execution output. */
+  private static final String RESULT_VAR  = "result";
+
+  /** Baseline script body; writes {@code "foo"} into the result variable. */
+  private static final String BASE_SCRIPT = "execution.setVariable('result', 'foo')";
+
+  /** Source value replaced by the first preprocessor. */
+  private static final String TEST_FOO = "'foo'";
+  /** Intermediate value produced by the first preprocessor. */
+  private static final String TEST_BAR = "'bar'";
+  /** Final value produced by the second preprocessor in chaining scenarios. */
+  private static final String TEST_BAZ = "'baz'";
+
+  /**
+   * Builds the Arquillian deployment for this class.
+   *
+   * @return web archive containing helper classes and the BPMN model under test
+   */
+  @Deployment
+  public static WebArchive createProcessApplication() {
+    BpmnModelInstance model = Bpmn.createExecutableProcess(PROCESS_KEY)
+        .fluxnovaHistoryTimeToLive(180)
+        .startEvent()
+        .scriptTask()
+          .scriptFormat(SCRIPT_LANG)
+          .scriptText(BASE_SCRIPT)
+        .userTask()
+        .done();
+    return initWebArchiveDeployment()
+        .addClass(ScriptPreprocessorTestHelper.class)
+        .addAsResource(new StringAsset(Bpmn.convertToString(model)), "process.bpmn20.xml");
+  }
+
+  /** Resets preprocessing configuration before each test to guarantee isolation. */
+  @Before
+  public void setUp() {
+    ScriptPreprocessorTestHelper.resetScriptPreprocessing(processEngineConfiguration);
+  }
+
+  /** Restores preprocessing configuration after each test to prevent state leakage. */
+  @After
+  public void tearDown() {
+    ScriptPreprocessorTestHelper.resetScriptPreprocessing(processEngineConfiguration);
+  }
+
+  /**
+   * Scenario 1: both preprocessing and compilation are enabled.
+   * Verifies that, with both flags enabled, preprocessing transforms the script and the
+   * transformed script result is observed at runtime.
+   */
+  @Test
+  public void preprocessingAndCompilationEnabled_returnsPreprocessedResult() {
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.setEnableScriptCompilation(true);
+    processEngineConfiguration.addScriptPreprocessor(
+        ScriptPreprocessorTestHelper.replacingPreprocessor(TEST_FOO, TEST_BAR));
+
+    String pid = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+
+    assertEquals("bar", runtimeService.getVariable(pid, RESULT_VAR));
+  }
+
+  /**
+   * Scenario 2: preprocessing disabled, compilation enabled.
+   * Verifies that disabling preprocessing preserves original script behavior even when
+   * compilation remains enabled.
+   */
+  @Test
+  public void preprocessingDisabled_compilationEnabled_returnsOriginalResult() {
+    processEngineConfiguration.setEnableScriptPreprocessing(false);
+    processEngineConfiguration.setEnableScriptCompilation(true);
+    processEngineConfiguration.addScriptPreprocessor(
+        ScriptPreprocessorTestHelper.replacingPreprocessor(TEST_FOO, TEST_BAR));
+
+    String pid = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+
+    assertEquals("foo", runtimeService.getVariable(pid, RESULT_VAR));
+  }
+
+  /**
+   * Scenario 3: preprocessing enabled, compilation disabled.
+   * Verifies that preprocessing still applies when compilation is disabled and the interpreted
+   * execution path is used.
+   */
+  @Test
+  public void preprocessingEnabled_compilationDisabled_returnsPreprocessedResult() {
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.setEnableScriptCompilation(false);
+    processEngineConfiguration.addScriptPreprocessor(
+        ScriptPreprocessorTestHelper.replacingPreprocessor(TEST_FOO, TEST_BAR));
+
+    String pid = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+
+    assertEquals("bar", runtimeService.getVariable(pid, RESULT_VAR));
+  }
+
+  /**
+   * Scenario 4: both preprocessing and compilation are disabled.
+   * Verifies baseline interpreted execution when both preprocessing and compilation are disabled.
+   */
+  @Test
+  public void preprocessingAndCompilationDisabled_returnsOriginalResult() {
+    processEngineConfiguration.setEnableScriptPreprocessing(false);
+    processEngineConfiguration.setEnableScriptCompilation(false);
+
+    String pid = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+
+    assertEquals("foo", runtimeService.getVariable(pid, RESULT_VAR));
+  }
+
+  /**
+   * Scenario 5: chained preprocessors with compilation enabled.
+   * Verifies that multiple preprocessors are applied in registration order.
+   * <p>Expected flow: {@code 'foo' -> 'bar' -> 'baz'}.</p>
+   */
+  @Test
+  public void chainingPreprocessors_appliedInOrder_returnsFinalResult() {
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.setEnableScriptCompilation(true);
+    // p1: 'foo' → 'bar'   p2: 'bar' → 'baz'
+    processEngineConfiguration.addScriptPreprocessor(
+        ScriptPreprocessorTestHelper.replacingPreprocessor(TEST_FOO, TEST_BAR));
+    processEngineConfiguration.addScriptPreprocessor(
+        ScriptPreprocessorTestHelper.replacingPreprocessor(TEST_BAR, TEST_BAZ));
+
+    String pid = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+
+    assertEquals("baz", runtimeService.getVariable(pid, RESULT_VAR));
+  }
+
+  /**
+   * Scenario 6: null-returning preprocessor with compilation enabled.
+   * Verifies null-safe fallback behavior with compilation enabled: when preprocessing yields
+   * {@code null}, the engine executes the original script.
+   */
+  @Test
+  public void nullReturningPreprocessor_compilationEnabled_fallsBackToOriginalScript() {
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.setEnableScriptCompilation(true);
+    processEngineConfiguration.addScriptPreprocessor(
+        ScriptPreprocessorTestHelper.nullReturningPreprocessor());
+
+    String pid = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+
+    assertEquals("foo", runtimeService.getVariable(pid, RESULT_VAR));
+  }
+
+  /**
+   * Scenario 7: explicit empty preprocessor list with compilation enabled.
+   * Verifies that an explicit empty preprocessor list behaves like "no preprocessors" and keeps
+   * original script output when compilation is enabled.
+   */
+  @Test
+  public void emptyPreprocessorList_compilationEnabled_returnsOriginalResult() {
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.setEnableScriptCompilation(true);
+    processEngineConfiguration.setScriptPreprocessors(Collections.emptyList());
+
+    String pid = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+
+    assertEquals("foo", runtimeService.getVariable(pid, RESULT_VAR));
+  }
+}

--- a/qa/integration-tests-engine/src/test/java/org/finos/fluxnova/bpm/integrationtest/functional/scriptengine/ScriptPreprocessorIntegrationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/finos/fluxnova/bpm/integrationtest/functional/scriptengine/ScriptPreprocessorIntegrationTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.bpm.integrationtest.functional.scriptengine;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.finos.fluxnova.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.finos.fluxnova.bpm.model.bpmn.Bpmn;
+import org.finos.fluxnova.bpm.model.bpmn.BpmnModelInstance;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Integration tests for script preprocessing in BPMN script tasks that rely on
+ * process-variable bindings.
+ *
+ * <p>This suite validates end-to-end behaviour in the container-managed runtime,
+ * including BPMN execution, script evaluation, variable resolution, and preprocessor
+ * invocation/fallback. The tests intentionally focus on variable-binding scenarios,
+ * as these require real engine integration and are not sufficiently represented by
+ * unit-level script evaluation tests.</p>
+ *
+ * <p>Coverage includes:</p>
+ * <ul>
+ *   <li>baseline execution with preprocessing disabled,</li>
+ *   <li>successful script transformation when preprocessing is enabled,</li>
+ *   <li>safe fallback when a preprocessor returns {@code null}, and</li>
+ *   <li>safe fallback when a preprocessor throws an exception.</li>
+ * </ul>
+ */
+@RunWith(Arquillian.class)
+public class ScriptPreprocessorIntegrationTest extends AbstractFoxPlatformIntegrationTest {
+
+  /** Process definition used for variable-binding scenarios. */
+  private static final String VAR_PROCESS_KEY = "scriptPreprocessorVarBindingProcess";
+  /** Script engine identifier used by BPMN script tasks in this suite. */
+  private static final String SCRIPT_LANGUAGE = "groovy";
+  /** Process variable receiving script evaluation output. */
+  private static final String RESULT_VARIABLE = "result";
+
+  /**
+   * Builds the Arquillian deployment for this test class.
+   *
+   * @return web archive containing helper classes and BPMN model resources
+   */
+  @Deployment
+  public static WebArchive createProcessApplication() {
+    return initWebArchiveDeployment()
+        .addClass(ScriptPreprocessorTestHelper.class)
+        .addAsResource(createVarBindingProcess(), "varBindingProcess.bpmn20.xml");
+  }
+
+  /** Restores script preprocessing settings before each test for isolation. */
+  @Before
+  public void beforeEach() {
+    ScriptPreprocessorTestHelper.resetScriptPreprocessing(processEngineConfiguration);
+  }
+
+  /** Restores script preprocessing settings after each test to avoid state leakage. */
+  @After
+  public void afterEach() {
+    ScriptPreprocessorTestHelper.resetScriptPreprocessing(processEngineConfiguration);
+  }
+
+  /**
+   * Validates baseline script execution with variable bindings when preprocessing is disabled.
+   *
+   * <p>The script computes {@code x + y} and stores the result in {@code result}.</p>
+   */
+  @Test
+  public void shouldEvaluateScriptWithVariableBindingsWhenPreprocessingDisabled() {
+    processEngineConfiguration.setEnableScriptPreprocessing(false);
+
+    Map<String, Object> vars = new HashMap<>();
+    vars.put("x", 4);
+    vars.put("y", 6);
+
+    String processInstanceId = runtimeService.startProcessInstanceByKey(VAR_PROCESS_KEY, vars).getId();
+
+    assertEquals(10, runtimeService.getVariable(processInstanceId, RESULT_VARIABLE));
+  }
+
+  /**
+   * Validates that preprocessing transforms scripts before execution when variable bindings
+   * are present.
+   *
+   * <p>The test rewrites {@code x + y} to {@code x * y} and verifies the transformed result.</p>
+   */
+  @Test
+  public void shouldApplyPreprocessorToScriptWithVariableBindings() {
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.addScriptPreprocessor(
+        ScriptPreprocessorTestHelper.replacingPreprocessor("x + y", "x * y"));
+
+    Map<String, Object> vars = new HashMap<>();
+    vars.put("x", 4);
+    vars.put("y", 6);
+
+    String processInstanceId = runtimeService.startProcessInstanceByKey(VAR_PROCESS_KEY, vars).getId();
+
+    assertEquals(24, runtimeService.getVariable(processInstanceId, RESULT_VARIABLE));
+  }
+
+  /**
+   * Validates null-safe fallback: when a preprocessor returns {@code null}, the engine executes
+   * the original script with the same variable bindings.
+   */
+  @Test
+  public void shouldFallBackToOriginalScriptWithVariableBindingsWhenPreprocessorReturnsNull() {
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.addScriptPreprocessor(ScriptPreprocessorTestHelper.nullReturningPreprocessor());
+
+    Map<String, Object> vars = new HashMap<>();
+    vars.put("x", 3);
+    vars.put("y", 7);
+
+    String processInstanceId = runtimeService.startProcessInstanceByKey(VAR_PROCESS_KEY, vars).getId();
+
+    assertEquals(10, runtimeService.getVariable(processInstanceId, RESULT_VARIABLE));
+  }
+
+  /**
+   * Validates exception-safe fallback: when a preprocessor throws, the engine executes the
+   * original script with the same variable bindings.
+   */
+  @Test
+  public void shouldFallBackToOriginalScriptWithVariableBindingsWhenPreprocessorThrows() {
+    processEngineConfiguration.setEnableScriptPreprocessing(true);
+    processEngineConfiguration.addScriptPreprocessor(ScriptPreprocessorTestHelper.throwingPreprocessor());
+
+    Map<String, Object> vars = new HashMap<>();
+    vars.put("x", 3);
+    vars.put("y", 7);
+
+    String processInstanceId = runtimeService.startProcessInstanceByKey(VAR_PROCESS_KEY, vars).getId();
+
+    assertEquals(10, runtimeService.getVariable(processInstanceId, RESULT_VARIABLE));
+  }
+
+  /**
+   * Creates the BPMN model used by this suite.
+   *
+   * <p>The model contains a single script task that evaluates {@code x + y} and writes the
+   * result to {@code result}, followed by a user task to keep the process state observable
+   * for assertions.</p>
+   */
+  private static StringAsset createVarBindingProcess() {
+    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess(VAR_PROCESS_KEY)
+        .fluxnovaHistoryTimeToLive(180)
+        .startEvent()
+        .scriptTask()
+          .scriptFormat(SCRIPT_LANGUAGE)
+          .scriptText("execution.setVariable('result', x + y)")
+        .userTask()
+        .done();
+    return new StringAsset(Bpmn.convertToString(modelInstance));
+  }
+
+}

--- a/qa/integration-tests-engine/src/test/java/org/finos/fluxnova/bpm/integrationtest/functional/scriptengine/ScriptPreprocessorTestHelper.java
+++ b/qa/integration-tests-engine/src/test/java/org/finos/fluxnova/bpm/integrationtest/functional/scriptengine/ScriptPreprocessorTestHelper.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 FINOS
+ *
+ * The source files in this repository are made available under the Apache License Version 2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Fluxnova uses and includes third-party dependencies published under various licenses.
+ * By downloading and using Fluxnova artifacts, you agree to their terms and conditions.
+ */
+package org.finos.fluxnova.bpm.integrationtest.functional.scriptengine;
+
+import org.finos.fluxnova.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessor;
+import org.finos.fluxnova.bpm.engine.impl.scripting.preprocessor.ScriptPreprocessorRequest;
+
+/**
+ * Shared factory methods for {@link ScriptPreprocessor} test doubles used by
+ * script engine integration tests.
+ */
+final class ScriptPreprocessorTestHelper {
+
+  private ScriptPreprocessorTestHelper() {
+  }
+
+  /**
+   * Creates a preprocessor that replaces all occurrences of {@code source} with
+   * {@code replacement} in the script text.
+   *
+   * @param source the text to replace
+   * @param replacement the replacement text
+   * @return a replacing preprocessor
+   */
+  static ScriptPreprocessor replacingPreprocessor(String source, String replacement) {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return request.getScript().replace(source, replacement);
+      }
+
+      @Override
+      public String getName() {
+        return "replacingPreprocessor[" + source + " -> " + replacement + "]";
+      }
+    };
+  }
+
+  /**
+   * Creates a preprocessor that always returns {@code null}, triggering fallback
+   * to the original script.
+   *
+   * @return a null-returning preprocessor
+   */
+  static ScriptPreprocessor nullReturningPreprocessor() {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        return null;
+      }
+
+      @Override
+      public String getName() {
+        return "nullReturningPreprocessor";
+      }
+    };
+  }
+
+  /**
+   * Creates a preprocessor that always throws a {@link RuntimeException},
+   * triggering exception-safe fallback to the original script.
+   *
+   * @return a throwing preprocessor
+   */
+  static ScriptPreprocessor throwingPreprocessor() {
+    return new ScriptPreprocessor() {
+      @Override
+      public String process(ScriptPreprocessorRequest request) {
+        throw new RuntimeException("Simulated preprocessing failure");
+      }
+
+      @Override
+      public String getName() {
+        return "throwingPreprocessor";
+      }
+    };
+  }
+
+  /**
+   * Resets script preprocessing configuration to a known default.
+   */
+  static void resetScriptPreprocessing(ProcessEngineConfigurationImpl config) {
+    config.setEnableScriptPreprocessing(false);
+    config.setScriptPreprocessors(null);
+  }
+}


### PR DESCRIPTION
### This PR adds support for script preprocessing in the engine.

**Introducing a script preprocessor SPI and configuration support to allow custom preprocessing of script content before evaluation. The default behavior remains unchanged unless script preprocessing is explicitly enabled.**

**The implementation includes:**
- support for registering one or more script preprocessors
- composition of multiple preprocessors in execution order
- safe fallback to the original script when preprocessing is disabled, no preprocessor is configured, a preprocessor returns null, or preprocessing fails
- related updates to configuration, scripting flow, logging, and documentation

**This PR also adds unit and integration tests covering:**
- enable/disable behavior
- chaining and ordering of preprocessors
- fallback behavior on null return or exception
- variable-binding scenarios during script execution

Fixes the Issue: #175 