### PR TITLE
fix: switch CronTimer cron type from SPRING53 to QUARTZ for correct c…

### DIFF
--- a/bom/fluxnova-bom/pom.xml
+++ b/bom/fluxnova-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-bom-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/bom/fluxnova-bom/pom.xml
+++ b/bom/fluxnova-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-bom-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/bom/fluxnova-bom/pom.xml
+++ b/bom/fluxnova-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-bom-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/bom/fluxnova-only-bom/pom.xml
+++ b/bom/fluxnova-only-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-bom-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/bom/fluxnova-only-bom/pom.xml
+++ b/bom/fluxnova-only-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-bom-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/bom/fluxnova-only-bom/pom.xml
+++ b/bom/fluxnova-only-bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-bom-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/clients/java/client/pom.xml
+++ b/clients/java/client/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-external-task-client-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/clients/java/client/pom.xml
+++ b/clients/java/client/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-external-task-client-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/clients/java/client/pom.xml
+++ b/clients/java/client/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-external-task-client-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <modules>

--- a/clients/java/qa/engine-variable-test/pom.xml
+++ b/clients/java/qa/engine-variable-test/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-external-task-client-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/clients/java/qa/engine-variable-test/pom.xml
+++ b/clients/java/qa/engine-variable-test/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-external-task-client-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/clients/java/qa/engine-variable-test/pom.xml
+++ b/clients/java/qa/engine-variable-test/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-external-task-client-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencies>

--- a/clients/java/qa/pom.xml
+++ b/clients/java/qa/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-external-task-client-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/clients/java/qa/pom.xml
+++ b/clients/java/qa/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-external-task-client-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <modules>

--- a/clients/java/qa/pom.xml
+++ b/clients/java/qa/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-external-task-client-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <modules>

--- a/commons/bom/pom.xml
+++ b/commons/bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/commons/bom/pom.xml
+++ b/commons/bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/commons/bom/pom.xml
+++ b/commons/bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/commons/logging/pom.xml
+++ b/commons/logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.commons</groupId>
     <artifactId>fluxnova-commons-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-commons-logging</artifactId>

--- a/commons/logging/pom.xml
+++ b/commons/logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.commons</groupId>
     <artifactId>fluxnova-commons-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-commons-logging</artifactId>

--- a/commons/logging/pom.xml
+++ b/commons/logging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.commons</groupId>
     <artifactId>fluxnova-commons-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-commons-logging</artifactId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.commons</groupId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.commons</groupId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.commons</groupId>

--- a/commons/testing/pom.xml
+++ b/commons/testing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.commons</groupId>
     <artifactId>fluxnova-commons-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-commons-testing</artifactId>

--- a/commons/testing/pom.xml
+++ b/commons/testing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.commons</groupId>
     <artifactId>fluxnova-commons-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-commons-testing</artifactId>

--- a/commons/testing/pom.xml
+++ b/commons/testing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.commons</groupId>
     <artifactId>fluxnova-commons-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-commons-testing</artifactId>

--- a/commons/typed-values/pom.xml
+++ b/commons/typed-values/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencyManagement>

--- a/commons/typed-values/pom.xml
+++ b/commons/typed-values/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/commons/typed-values/pom.xml
+++ b/commons/typed-values/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/commons/utils/pom.xml
+++ b/commons/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.commons</groupId>
     <artifactId>fluxnova-commons-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-commons-utils</artifactId>

--- a/commons/utils/pom.xml
+++ b/commons/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.commons</groupId>
     <artifactId>fluxnova-commons-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-commons-utils</artifactId>

--- a/commons/utils/pom.xml
+++ b/commons/utils/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.commons</groupId>
     <artifactId>fluxnova-commons-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-commons-utils</artifactId>

--- a/connect/bom/pom.xml
+++ b/connect/bom/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <groupId>org.finos.fluxnova.connect</groupId>
   <artifactId>fluxnova-connect-bom</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>2.0.1-SNAPSHOT</version>
   <name>Fluxnova Platform - connect - bom</name>
   <packaging>pom</packaging>
 

--- a/connect/bom/pom.xml
+++ b/connect/bom/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <groupId>org.finos.fluxnova.connect</groupId>
   <artifactId>fluxnova-connect-bom</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.1</version>
   <name>Fluxnova Platform - connect - bom</name>
   <packaging>pom</packaging>
 

--- a/connect/bom/pom.xml
+++ b/connect/bom/pom.xml
@@ -6,13 +6,13 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <groupId>org.finos.fluxnova.connect</groupId>
   <artifactId>fluxnova-connect-bom</artifactId>
-  <version>2.0.1</version>
+  <version>2.1.0-SNAPSHOT</version>
   <name>Fluxnova Platform - connect - bom</name>
   <packaging>pom</packaging>
 

--- a/connect/connectors-all/pom.xml
+++ b/connect/connectors-all/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.connect</groupId>
     <artifactId>fluxnova-connect-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-connect-connectors-all</artifactId>

--- a/connect/connectors-all/pom.xml
+++ b/connect/connectors-all/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.connect</groupId>
     <artifactId>fluxnova-connect-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-connect-connectors-all</artifactId>

--- a/connect/connectors-all/pom.xml
+++ b/connect/connectors-all/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.connect</groupId>
     <artifactId>fluxnova-connect-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-connect-connectors-all</artifactId>

--- a/connect/core/pom.xml
+++ b/connect/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.connect</groupId>
     <artifactId>fluxnova-connect-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-connect-core</artifactId>

--- a/connect/core/pom.xml
+++ b/connect/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.connect</groupId>
     <artifactId>fluxnova-connect-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-connect-core</artifactId>

--- a/connect/core/pom.xml
+++ b/connect/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.connect</groupId>
     <artifactId>fluxnova-connect-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-connect-core</artifactId>

--- a/connect/http-client/pom.xml
+++ b/connect/http-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>fluxnova-connect-root</artifactId>
     <groupId>org.finos.fluxnova.connect</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/connect/http-client/pom.xml
+++ b/connect/http-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>fluxnova-connect-root</artifactId>
     <groupId>org.finos.fluxnova.connect</groupId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/connect/http-client/pom.xml
+++ b/connect/http-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>fluxnova-connect-root</artifactId>
     <groupId>org.finos.fluxnova.connect</groupId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.connect</groupId>

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.connect</groupId>

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.connect</groupId>

--- a/connect/soap-http-client/pom.xml
+++ b/connect/soap-http-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.connect</groupId>
     <artifactId>fluxnova-connect-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-connect-soap-http-client</artifactId>

--- a/connect/soap-http-client/pom.xml
+++ b/connect/soap-http-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.connect</groupId>
     <artifactId>fluxnova-connect-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-connect-soap-http-client</artifactId>

--- a/connect/soap-http-client/pom.xml
+++ b/connect/soap-http-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.connect</groupId>
     <artifactId>fluxnova-connect-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-connect-soap-http-client</artifactId>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-database-settings</artifactId>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-database-settings</artifactId>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-database-settings</artifactId>

--- a/distro/jboss/pom.xml
+++ b/distro/jboss/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   
   <groupId>org.finos.fluxnova.bpm.jboss</groupId>

--- a/distro/jboss/pom.xml
+++ b/distro/jboss/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
   
   <groupId>org.finos.fluxnova.bpm.jboss</groupId>

--- a/distro/jboss/pom.xml
+++ b/distro/jboss/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
   
   <groupId>org.finos.fluxnova.bpm.jboss</groupId>

--- a/distro/jboss/webapp/pom.xml
+++ b/distro/jboss/webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.jboss</groupId>
     <artifactId>fluxnova-jboss</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distro/jboss/webapp/pom.xml
+++ b/distro/jboss/webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.jboss</groupId>
     <artifactId>fluxnova-jboss</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distro/jboss/webapp/pom.xml
+++ b/distro/jboss/webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.jboss</groupId>
     <artifactId>fluxnova-jboss</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distro/license-book/pom.xml
+++ b/distro/license-book/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>license-book</artifactId>

--- a/distro/license-book/pom.xml
+++ b/distro/license-book/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>license-book</artifactId>

--- a/distro/license-book/pom.xml
+++ b/distro/license-book/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>license-book</artifactId>

--- a/distro/run/assembly/pom.xml
+++ b/distro/run/assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/assembly/pom.xml
+++ b/distro/run/assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/assembly/pom.xml
+++ b/distro/run/assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/core/pom.xml
+++ b/distro/run/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/core/pom.xml
+++ b/distro/run/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/core/pom.xml
+++ b/distro/run/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/distro/pom.xml
+++ b/distro/run/distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/distro/pom.xml
+++ b/distro/run/distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/distro/pom.xml
+++ b/distro/run/distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/example/pom.xml
+++ b/distro/run/modules/example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-modules</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpm-run-modules-example-invoice</artifactId>

--- a/distro/run/modules/example/pom.xml
+++ b/distro/run/modules/example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-modules</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpm-run-modules-example-invoice</artifactId>

--- a/distro/run/modules/example/pom.xml
+++ b/distro/run/modules/example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-modules</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-bpm-run-modules-example-invoice</artifactId>

--- a/distro/run/modules/oauth2/pom.xml
+++ b/distro/run/modules/oauth2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-modules</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/oauth2/pom.xml
+++ b/distro/run/modules/oauth2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-modules</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/oauth2/pom.xml
+++ b/distro/run/modules/oauth2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-modules</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/pom.xml
+++ b/distro/run/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/pom.xml
+++ b/distro/run/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/pom.xml
+++ b/distro/run/modules/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/rest/pom.xml
+++ b/distro/run/modules/rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-modules</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/rest/pom.xml
+++ b/distro/run/modules/rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-modules</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/rest/pom.xml
+++ b/distro/run/modules/rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-modules</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/webapps/pom.xml
+++ b/distro/run/modules/webapps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-modules</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/webapps/pom.xml
+++ b/distro/run/modules/webapps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-modules</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/modules/webapps/pom.xml
+++ b/distro/run/modules/webapps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-modules</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../../database</relativePath>
   </parent>
 

--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../../database</relativePath>
   </parent>
 

--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../../database</relativePath>
   </parent>
 

--- a/distro/run/qa/example-plugin/pom.xml
+++ b/distro/run/qa/example-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/example-plugin/pom.xml
+++ b/distro/run/qa/example-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/example-plugin/pom.xml
+++ b/distro/run/qa/example-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/integration-tests/pom.xml
+++ b/distro/run/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/integration-tests/pom.xml
+++ b/distro/run/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/integration-tests/pom.xml
+++ b/distro/run/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/pom.xml
+++ b/distro/run/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/pom.xml
+++ b/distro/run/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/pom.xml
+++ b/distro/run/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.run</groupId>
     <artifactId>fluxnova-bpm-run-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/distro/sql-script/pom.xml
+++ b/distro/sql-script/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.distro</groupId>

--- a/distro/sql-script/pom.xml
+++ b/distro/sql-script/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.distro</groupId>

--- a/distro/sql-script/pom.xml
+++ b/distro/sql-script/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.distro</groupId>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.tomcat</groupId>
     <artifactId>fluxnova-tomcat</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
   
   <properties>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.tomcat</groupId>
     <artifactId>fluxnova-tomcat</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
   
   <properties>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.tomcat</groupId>
     <artifactId>fluxnova-tomcat</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   
   <properties>

--- a/distro/tomcat/distro/pom.xml
+++ b/distro/tomcat/distro/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.tomcat</groupId>
     <artifactId>fluxnova-tomcat</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Fluxnova Platform - tomcat Distro</name>

--- a/distro/tomcat/distro/pom.xml
+++ b/distro/tomcat/distro/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.tomcat</groupId>
     <artifactId>fluxnova-tomcat</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <name>Fluxnova Platform - tomcat Distro</name>

--- a/distro/tomcat/distro/pom.xml
+++ b/distro/tomcat/distro/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.tomcat</groupId>
     <artifactId>fluxnova-tomcat</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <name>Fluxnova Platform - tomcat Distro</name>

--- a/distro/tomcat/pom.xml
+++ b/distro/tomcat/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-tomcat</artifactId>

--- a/distro/tomcat/pom.xml
+++ b/distro/tomcat/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-tomcat</artifactId>

--- a/distro/tomcat/pom.xml
+++ b/distro/tomcat/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-tomcat</artifactId>

--- a/distro/tomcat/webapp-jakarta/pom.xml
+++ b/distro/tomcat/webapp-jakarta/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.tomcat</groupId>
     <artifactId>fluxnova-tomcat</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distro/tomcat/webapp-jakarta/pom.xml
+++ b/distro/tomcat/webapp-jakarta/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.tomcat</groupId>
     <artifactId>fluxnova-tomcat</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distro/tomcat/webapp-jakarta/pom.xml
+++ b/distro/tomcat/webapp-jakarta/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.tomcat</groupId>
     <artifactId>fluxnova-tomcat</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distro/webjar/pom.xml
+++ b/distro/webjar/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.webapp</groupId>

--- a/distro/webjar/pom.xml
+++ b/distro/webjar/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.webapp</groupId>

--- a/distro/webjar/pom.xml
+++ b/distro/webjar/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.webapp</groupId>

--- a/distro/wildfly/assembly/pom.xml
+++ b/distro/wildfly/assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-wildfly-assembly</artifactId>

--- a/distro/wildfly/assembly/pom.xml
+++ b/distro/wildfly/assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-wildfly-assembly</artifactId>

--- a/distro/wildfly/assembly/pom.xml
+++ b/distro/wildfly/assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-wildfly-assembly</artifactId>

--- a/distro/wildfly/distro/pom.xml
+++ b/distro/wildfly/distro/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-bpm-wildfly</artifactId>

--- a/distro/wildfly/distro/pom.xml
+++ b/distro/wildfly/distro/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpm-wildfly</artifactId>

--- a/distro/wildfly/distro/pom.xml
+++ b/distro/wildfly/distro/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpm-wildfly</artifactId>

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-wildfly-modules</artifactId>

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-wildfly-modules</artifactId>

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-wildfly-modules</artifactId>

--- a/distro/wildfly/pom.xml
+++ b/distro/wildfly/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   
   <groupId>org.finos.fluxnova.bpm.wildfly</groupId>

--- a/distro/wildfly/pom.xml
+++ b/distro/wildfly/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
   
   <groupId>org.finos.fluxnova.bpm.wildfly</groupId>

--- a/distro/wildfly/pom.xml
+++ b/distro/wildfly/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
   
   <groupId>org.finos.fluxnova.bpm.wildfly</groupId>

--- a/distro/wildfly/subsystem/pom.xml
+++ b/distro/wildfly/subsystem/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-wildfly-subsystem</artifactId>

--- a/distro/wildfly/subsystem/pom.xml
+++ b/distro/wildfly/subsystem/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-wildfly-subsystem</artifactId>

--- a/distro/wildfly/subsystem/pom.xml
+++ b/distro/wildfly/subsystem/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-wildfly-subsystem</artifactId>

--- a/distro/wildfly/webapp/pom.xml
+++ b/distro/wildfly/webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distro/wildfly/webapp/pom.xml
+++ b/distro/wildfly/webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distro/wildfly/webapp/pom.xml
+++ b/distro/wildfly/webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distro/wildfly26/modules/pom.xml
+++ b/distro/wildfly26/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly26</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-wildfly26-modules</artifactId>

--- a/distro/wildfly26/modules/pom.xml
+++ b/distro/wildfly26/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly26</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-wildfly26-modules</artifactId>

--- a/distro/wildfly26/modules/pom.xml
+++ b/distro/wildfly26/modules/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly26</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-wildfly26-modules</artifactId>

--- a/distro/wildfly26/pom.xml
+++ b/distro/wildfly26/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   
   <groupId>org.finos.fluxnova.bpm.wildfly</groupId>

--- a/distro/wildfly26/pom.xml
+++ b/distro/wildfly26/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
   
   <groupId>org.finos.fluxnova.bpm.wildfly</groupId>

--- a/distro/wildfly26/pom.xml
+++ b/distro/wildfly26/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
   
   <groupId>org.finos.fluxnova.bpm.wildfly</groupId>

--- a/distro/wildfly26/subsystem/pom.xml
+++ b/distro/wildfly26/subsystem/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly26</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-wildfly26-subsystem</artifactId>

--- a/distro/wildfly26/subsystem/pom.xml
+++ b/distro/wildfly26/subsystem/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly26</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-wildfly26-subsystem</artifactId>

--- a/distro/wildfly26/subsystem/pom.xml
+++ b/distro/wildfly26/subsystem/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.wildfly</groupId>
     <artifactId>fluxnova-wildfly26</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-wildfly26-subsystem</artifactId>

--- a/engine-cdi/core/pom.xml
+++ b/engine-cdi/core/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/engine-cdi/core/pom.xml
+++ b/engine-cdi/core/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-cdi/core/pom.xml
+++ b/engine-cdi/core/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-cdi/jakarta/pom.xml
+++ b/engine-cdi/jakarta/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/engine-cdi/jakarta/pom.xml
+++ b/engine-cdi/jakarta/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-cdi/jakarta/pom.xml
+++ b/engine-cdi/jakarta/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-cdi/pom.xml
+++ b/engine-cdi/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-cdi-compatibility-root</artifactId>

--- a/engine-cdi/pom.xml
+++ b/engine-cdi/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-cdi-compatibility-root</artifactId>

--- a/engine-cdi/pom.xml
+++ b/engine-cdi/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-cdi-compatibility-root</artifactId>

--- a/engine-dmn/bom/pom.xml
+++ b/engine-dmn/bom/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.dmn</groupId>
   <artifactId>fluxnova-engine-dmn-bom</artifactId>
-  <version>2.0.1</version>
+  <version>2.1.0-SNAPSHOT</version>
   <name>fluxnova DMN - engine - bom</name>
   <packaging>pom</packaging>
 

--- a/engine-dmn/bom/pom.xml
+++ b/engine-dmn/bom/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.dmn</groupId>
   <artifactId>fluxnova-engine-dmn-bom</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.1</version>
   <name>fluxnova DMN - engine - bom</name>
   <packaging>pom</packaging>
 

--- a/engine-dmn/bom/pom.xml
+++ b/engine-dmn/bom/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.dmn</groupId>
   <artifactId>fluxnova-engine-dmn-bom</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>2.0.1-SNAPSHOT</version>
   <name>fluxnova DMN - engine - bom</name>
   <packaging>pom</packaging>
 

--- a/engine-dmn/engine/pom.xml
+++ b/engine-dmn/engine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.dmn</groupId>
     <artifactId>fluxnova-engine-dmn-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-engine-dmn</artifactId>

--- a/engine-dmn/engine/pom.xml
+++ b/engine-dmn/engine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.dmn</groupId>
     <artifactId>fluxnova-engine-dmn-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-engine-dmn</artifactId>

--- a/engine-dmn/engine/pom.xml
+++ b/engine-dmn/engine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.dmn</groupId>
     <artifactId>fluxnova-engine-dmn-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-engine-dmn</artifactId>

--- a/engine-dmn/feel-api/pom.xml
+++ b/engine-dmn/feel-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.dmn</groupId>
     <artifactId>fluxnova-engine-dmn-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-engine-feel-api</artifactId>

--- a/engine-dmn/feel-api/pom.xml
+++ b/engine-dmn/feel-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.dmn</groupId>
     <artifactId>fluxnova-engine-dmn-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-engine-feel-api</artifactId>

--- a/engine-dmn/feel-api/pom.xml
+++ b/engine-dmn/feel-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.dmn</groupId>
     <artifactId>fluxnova-engine-dmn-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-engine-feel-api</artifactId>

--- a/engine-dmn/feel-juel/pom.xml
+++ b/engine-dmn/feel-juel/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.dmn</groupId>
     <artifactId>fluxnova-engine-dmn-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-engine-feel-juel</artifactId>

--- a/engine-dmn/feel-juel/pom.xml
+++ b/engine-dmn/feel-juel/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.dmn</groupId>
     <artifactId>fluxnova-engine-dmn-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-engine-feel-juel</artifactId>

--- a/engine-dmn/feel-juel/pom.xml
+++ b/engine-dmn/feel-juel/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.dmn</groupId>
     <artifactId>fluxnova-engine-dmn-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-engine-feel-juel</artifactId>

--- a/engine-dmn/feel-scala/pom.xml
+++ b/engine-dmn/feel-scala/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.dmn</groupId>
     <artifactId>fluxnova-engine-dmn-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-engine-feel-scala</artifactId>

--- a/engine-dmn/feel-scala/pom.xml
+++ b/engine-dmn/feel-scala/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.dmn</groupId>
     <artifactId>fluxnova-engine-dmn-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-engine-feel-scala</artifactId>

--- a/engine-dmn/feel-scala/pom.xml
+++ b/engine-dmn/feel-scala/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.dmn</groupId>
     <artifactId>fluxnova-engine-dmn-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-engine-feel-scala</artifactId>

--- a/engine-dmn/pom.xml
+++ b/engine-dmn/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.dmn</groupId>

--- a/engine-dmn/pom.xml
+++ b/engine-dmn/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.dmn</groupId>

--- a/engine-dmn/pom.xml
+++ b/engine-dmn/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.dmn</groupId>

--- a/engine-plugins/connect-plugin/pom.xml
+++ b/engine-plugins/connect-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>fluxnova-engine-plugins</artifactId>
     <groupId>org.finos.fluxnova.bpm</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/engine-plugins/connect-plugin/pom.xml
+++ b/engine-plugins/connect-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>fluxnova-engine-plugins</artifactId>
     <groupId>org.finos.fluxnova.bpm</groupId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/engine-plugins/connect-plugin/pom.xml
+++ b/engine-plugins/connect-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>fluxnova-engine-plugins</artifactId>
     <groupId>org.finos.fluxnova.bpm</groupId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/engine-plugins/identity-ldap/pom.xml
+++ b/engine-plugins/identity-ldap/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-plugins</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/engine-plugins/identity-ldap/pom.xml
+++ b/engine-plugins/identity-ldap/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-plugins</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-plugins/identity-ldap/pom.xml
+++ b/engine-plugins/identity-ldap/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-plugins</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-plugins/pom.xml
+++ b/engine-plugins/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-engine-plugins</artifactId>

--- a/engine-plugins/pom.xml
+++ b/engine-plugins/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-engine-plugins</artifactId>

--- a/engine-plugins/pom.xml
+++ b/engine-plugins/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-engine-plugins</artifactId>

--- a/engine-plugins/spin-plugin/pom.xml
+++ b/engine-plugins/spin-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>fluxnova-engine-plugins</artifactId>
     <groupId>org.finos.fluxnova.bpm</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/engine-plugins/spin-plugin/pom.xml
+++ b/engine-plugins/spin-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>fluxnova-engine-plugins</artifactId>
     <groupId>org.finos.fluxnova.bpm</groupId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/engine-plugins/spin-plugin/pom.xml
+++ b/engine-plugins/spin-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>fluxnova-engine-plugins</artifactId>
     <groupId>org.finos.fluxnova.bpm</groupId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/engine-rest/assembly-jakarta/pom.xml
+++ b/engine-rest/assembly-jakarta/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/engine-rest/assembly-jakarta/pom.xml
+++ b/engine-rest/assembly-jakarta/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/assembly-jakarta/pom.xml
+++ b/engine-rest/assembly-jakarta/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/assembly/pom.xml
+++ b/engine-rest/assembly/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
   
   <properties>

--- a/engine-rest/assembly/pom.xml
+++ b/engine-rest/assembly/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   
   <properties>

--- a/engine-rest/assembly/pom.xml
+++ b/engine-rest/assembly/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
   
   <properties>

--- a/engine-rest/docs/pom.xml
+++ b/engine-rest/docs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <groupId>org.finos.fluxnova.bpm</groupId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/engine-rest/docs/pom.xml
+++ b/engine-rest/docs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <groupId>org.finos.fluxnova.bpm</groupId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/engine-rest/docs/pom.xml
+++ b/engine-rest/docs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <groupId>org.finos.fluxnova.bpm</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest-openapi-generator/pom.xml
+++ b/engine-rest/engine-rest-openapi-generator/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest-openapi-generator/pom.xml
+++ b/engine-rest/engine-rest-openapi-generator/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest-openapi-generator/pom.xml
+++ b/engine-rest/engine-rest-openapi-generator/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest-openapi/pom.xml
+++ b/engine-rest/engine-rest-openapi/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest-openapi/pom.xml
+++ b/engine-rest/engine-rest-openapi/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest-openapi/pom.xml
+++ b/engine-rest/engine-rest-openapi/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-engine-rest-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/engine-rest/pom.xml
+++ b/engine-rest/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-engine-rest-root</artifactId>

--- a/engine-rest/pom.xml
+++ b/engine-rest/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-engine-rest-root</artifactId>

--- a/engine-rest/pom.xml
+++ b/engine-rest/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-engine-rest-root</artifactId>

--- a/engine-spring/core-6/pom.xml
+++ b/engine-spring/core-6/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencyManagement>

--- a/engine-spring/core-6/pom.xml
+++ b/engine-spring/core-6/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/engine-spring/core-6/pom.xml
+++ b/engine-spring/core-6/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/engine-spring/core/pom.xml
+++ b/engine-spring/core/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencyManagement>

--- a/engine-spring/core/pom.xml
+++ b/engine-spring/core/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/engine-spring/core/pom.xml
+++ b/engine-spring/core/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/engine-spring/pom.xml
+++ b/engine-spring/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-spring-compatibility-root</artifactId>

--- a/engine-spring/pom.xml
+++ b/engine-spring/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-spring-compatibility-root</artifactId>

--- a/engine-spring/pom.xml
+++ b/engine-spring/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-spring-compatibility-root</artifactId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencyManagement>

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/calendar/CronTimer.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/calendar/CronTimer.java
@@ -52,7 +52,7 @@ public class CronTimer {
     public static CronTimer parse(final String text) throws ParseException {
         try {
             final var cron =
-                    new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING53))
+                    new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ))
                             .parse(text);
             return new CronTimer(cron);
         } catch (final IllegalArgumentException | NullPointerException ex) {

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/test/standalone/calendar/CycleBusinessCalendarTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/test/standalone/calendar/CycleBusinessCalendarTest.java
@@ -109,7 +109,7 @@ public class CycleBusinessCalendarTest {
     assertThat(sdf.format(cbc.resolveDuedate("0 0 9-17 * * ?", startDate))).isEqualTo("2010 02 12 09:00");
     assertThat(sdf.format(cbc.resolveDuedate("0 0 0 25 12 ?", startDate))).isEqualTo("2010 12 25 00:00");
     assertThat(sdf.format(cbc.resolveDuedate("0 0 0 L 12 ?", startDate))).isEqualTo("2010 12 31 00:00");
-    assertThat(sdf.format(cbc.resolveDuedate("0 0 * 1|2 * ?", startDate))).isEqualTo("2010 03 01 00:00");
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 * 1,2 * ?", startDate))).isEqualTo("2010 03 01 00:00");
     assertThat(sdf.format(cbc.resolveDuedate("0 0 6,19 * * ?", startDate))).isEqualTo("2010 02 11 19:00");
   }
 
@@ -120,16 +120,18 @@ public class CycleBusinessCalendarTest {
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy MM dd HH:mm");
     Date startDate = sdf.parse("2010 02 11 17:23");
 
-    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 * * THUL", startDate))).isEqualTo("2010 02 25 00:00");
-    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 1W * *", startDate))).isEqualTo("2010 03 01 00:00");
-    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 ? * 5#2", startDate))).isEqualTo("2010 02 12 00:00");
-    assertThat(sdf.format(cbc.resolveDuedate("@monthly", startDate))).isEqualTo("2010 03 01 00:00");
-    assertThat(sdf.format(cbc.resolveDuedate("@annually", startDate))).isEqualTo("2011 01 01 00:00");
-    assertThat(sdf.format(cbc.resolveDuedate("@yearly", startDate))).isEqualTo("2011 01 01 00:00");
-    assertThat(sdf.format(cbc.resolveDuedate("@weekly", startDate))).isEqualTo("2010 02 14 00:00");
-    assertThat(sdf.format(cbc.resolveDuedate("@daily", startDate))).isEqualTo("2010 02 12 00:00");
-    assertThat(sdf.format(cbc.resolveDuedate("@midnight", startDate))).isEqualTo("2010 02 12 00:00");
-    assertThat(sdf.format(cbc.resolveDuedate("@hourly", startDate))).isEqualTo("2010 02 11 18:00");
+    // QUARTZ day-of-week: 1=Sun, 2=Mon, 3=Tue, 4=Wed, 5=Thu, 6=Fri, 7=Sat
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 ? * 5L", startDate))).isEqualTo("2010 02 25 00:00"); // last Thursday (5=Thu in QUARTZ)
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 1W * ?", startDate))).isEqualTo("2010 03 01 00:00"); // nearest weekday to 1st
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 ? * 6#2", startDate))).isEqualTo("2010 02 12 00:00"); // 2nd Friday (6=Fri in QUARTZ)
+    // Macros are not supported in QUARTZ format; use equivalent explicit QUARTZ cron expressions instead
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 1 * ?", startDate))).isEqualTo("2010 03 01 00:00");  // @monthly equivalent
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 1 1 ?", startDate))).isEqualTo("2011 01 01 00:00");  // @annually equivalent
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 1 1 ?", startDate))).isEqualTo("2011 01 01 00:00");  // @yearly equivalent
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 ? * 1", startDate))).isEqualTo("2010 02 14 00:00");  // @weekly equivalent (1=Sun in QUARTZ)
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 * * ?", startDate))).isEqualTo("2010 02 12 00:00");  // @daily equivalent
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 * * ?", startDate))).isEqualTo("2010 02 12 00:00");  // @midnight equivalent
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 * * * ?", startDate))).isEqualTo("2010 02 11 18:00");  // @hourly equivalent
   }
 
   @Test

--- a/examples/invoice-jakarta/pom.xml
+++ b/examples/invoice-jakarta/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm.example</groupId>
     <artifactId>fluxnova-example-root</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/examples/invoice-jakarta/pom.xml
+++ b/examples/invoice-jakarta/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm.example</groupId>
     <artifactId>fluxnova-example-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/examples/invoice-jakarta/pom.xml
+++ b/examples/invoice-jakarta/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm.example</groupId>
     <artifactId>fluxnova-example-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencyManagement>

--- a/examples/invoice/pom.xml
+++ b/examples/invoice/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm.example</groupId>
     <artifactId>fluxnova-example-root</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/examples/invoice/pom.xml
+++ b/examples/invoice/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm.example</groupId>
     <artifactId>fluxnova-example-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/examples/invoice/pom.xml
+++ b/examples/invoice/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm.example</groupId>
     <artifactId>fluxnova-example-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/freemarker-template-engine/pom.xml
+++ b/freemarker-template-engine/pom.xml
@@ -5,12 +5,12 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.template-engines</groupId>
   <artifactId>fluxnova-template-engines-freemarker</artifactId>
-  <version>2.0.1</version>
+  <version>2.1.0-SNAPSHOT</version>
   
   <name>fluxnova template engine jsr223 freemarker</name>
 

--- a/freemarker-template-engine/pom.xml
+++ b/freemarker-template-engine/pom.xml
@@ -5,12 +5,12 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.template-engines</groupId>
   <artifactId>fluxnova-template-engines-freemarker</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.1</version>
   
   <name>fluxnova template engine jsr223 freemarker</name>
 

--- a/freemarker-template-engine/pom.xml
+++ b/freemarker-template-engine/pom.xml
@@ -5,12 +5,12 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.template-engines</groupId>
   <artifactId>fluxnova-template-engines-freemarker</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>2.0.1-SNAPSHOT</version>
   
   <name>fluxnova template engine jsr223 freemarker</name>
 

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-core-internal-dependencies</artifactId>

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-core-internal-dependencies</artifactId>

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-core-internal-dependencies</artifactId>

--- a/javaee/ejb-client-jakarta/pom.xml
+++ b/javaee/ejb-client-jakarta/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/ejb-client-jakarta/pom.xml
+++ b/javaee/ejb-client-jakarta/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/ejb-client-jakarta/pom.xml
+++ b/javaee/ejb-client-jakarta/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/ejb-client/pom.xml
+++ b/javaee/ejb-client/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/ejb-client/pom.xml
+++ b/javaee/ejb-client/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/ejb-client/pom.xml
+++ b/javaee/ejb-client/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/ejb-service/pom.xml
+++ b/javaee/ejb-service/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/ejb-service/pom.xml
+++ b/javaee/ejb-service/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/ejb-service/pom.xml
+++ b/javaee/ejb-service/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/jobexecutor-ra/pom.xml
+++ b/javaee/jobexecutor-ra/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/javaee/jobexecutor-ra/pom.xml
+++ b/javaee/jobexecutor-ra/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/javaee/jobexecutor-ra/pom.xml
+++ b/javaee/jobexecutor-ra/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/javaee/jobexecutor-rar/pom.xml
+++ b/javaee/jobexecutor-rar/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/jobexecutor-rar/pom.xml
+++ b/javaee/jobexecutor-rar/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/jobexecutor-rar/pom.xml
+++ b/javaee/jobexecutor-rar/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/juel/pom.xml
+++ b/juel/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.juel</groupId>

--- a/juel/pom.xml
+++ b/juel/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.juel</groupId>

--- a/juel/pom.xml
+++ b/juel/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.juel</groupId>

--- a/migrator/pom.xml
+++ b/migrator/pom.xml
@@ -5,7 +5,7 @@
         <groupId>org.finos.fluxnova.bpm</groupId>
         <artifactId>fluxnova-parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <groupId>org.finos.fluxnova</groupId>

--- a/migrator/pom.xml
+++ b/migrator/pom.xml
@@ -5,7 +5,7 @@
         <groupId>org.finos.fluxnova.bpm</groupId>
         <artifactId>fluxnova-parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>2.0.1</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.finos.fluxnova</groupId>

--- a/migrator/pom.xml
+++ b/migrator/pom.xml
@@ -5,7 +5,7 @@
         <groupId>org.finos.fluxnova.bpm</groupId>
         <artifactId>fluxnova-parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.finos.fluxnova</groupId>

--- a/model-api/bpmn-model/pom.xml
+++ b/model-api/bpmn-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm.model</groupId>
     <artifactId>fluxnova-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpmn-model</artifactId>

--- a/model-api/bpmn-model/pom.xml
+++ b/model-api/bpmn-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm.model</groupId>
     <artifactId>fluxnova-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpmn-model</artifactId>

--- a/model-api/bpmn-model/pom.xml
+++ b/model-api/bpmn-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm.model</groupId>
     <artifactId>fluxnova-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-bpmn-model</artifactId>

--- a/model-api/cmmn-model/pom.xml
+++ b/model-api/cmmn-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm.model</groupId>
     <artifactId>fluxnova-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-cmmn-model</artifactId>

--- a/model-api/cmmn-model/pom.xml
+++ b/model-api/cmmn-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm.model</groupId>
     <artifactId>fluxnova-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-cmmn-model</artifactId>

--- a/model-api/cmmn-model/pom.xml
+++ b/model-api/cmmn-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm.model</groupId>
     <artifactId>fluxnova-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-cmmn-model</artifactId>

--- a/model-api/dmn-model/pom.xml
+++ b/model-api/dmn-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm.model</groupId>
     <artifactId>fluxnova-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-dmn-model</artifactId>

--- a/model-api/dmn-model/pom.xml
+++ b/model-api/dmn-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm.model</groupId>
     <artifactId>fluxnova-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-dmn-model</artifactId>

--- a/model-api/dmn-model/pom.xml
+++ b/model-api/dmn-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm.model</groupId>
     <artifactId>fluxnova-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-dmn-model</artifactId>

--- a/model-api/pom.xml
+++ b/model-api/pom.xml
@@ -12,7 +12,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/model-api/pom.xml
+++ b/model-api/pom.xml
@@ -12,7 +12,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/model-api/pom.xml
+++ b/model-api/pom.xml
@@ -12,7 +12,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencyManagement>

--- a/model-api/xml-model/pom.xml
+++ b/model-api/xml-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm.model</groupId>
     <artifactId>fluxnova-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-xml-model</artifactId>

--- a/model-api/xml-model/pom.xml
+++ b/model-api/xml-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm.model</groupId>
     <artifactId>fluxnova-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-xml-model</artifactId>

--- a/model-api/xml-model/pom.xml
+++ b/model-api/xml-model/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm.model</groupId>
     <artifactId>fluxnova-model-apis</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-xml-model</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.finos.fluxnova.bpm</groupId>
   <artifactId>fluxnova-root</artifactId>
-  <version>2.0.1</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Fluxnova Platform - Root Pom</name>
   <inceptionYear>2013</inceptionYear>
@@ -27,7 +27,7 @@
     <connection>scm:git:https://github.com/finos/fluxnova-bpm-platform.git</connection>
     <developerConnection>scm:git:https://github.com/finos/fluxnova-bpm-platform.git</developerConnection>
     <url>https://github.com/finos/fluxnova-bpm-platform</url>
-    <tag>v2.0.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.finos.fluxnova.bpm</groupId>
   <artifactId>fluxnova-root</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.1</version>
   <packaging>pom</packaging>
   <name>Fluxnova Platform - Root Pom</name>
   <inceptionYear>2013</inceptionYear>
@@ -27,7 +27,7 @@
     <connection>scm:git:https://github.com/finos/fluxnova-bpm-platform.git</connection>
     <developerConnection>scm:git:https://github.com/finos/fluxnova-bpm-platform.git</developerConnection>
     <url>https://github.com/finos/fluxnova-bpm-platform</url>
-    <tag>HEAD</tag>
+    <tag>v2.0.1</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.finos.fluxnova.bpm</groupId>
   <artifactId>fluxnova-root</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>2.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Fluxnova Platform - Root Pom</name>
   <inceptionYear>2013</inceptionYear>

--- a/qa/ensure-clean-db-plugin/pom.xml
+++ b/qa/ensure-clean-db-plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>fluxnova-qa</artifactId>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/qa/ensure-clean-db-plugin/pom.xml
+++ b/qa/ensure-clean-db-plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>fluxnova-qa</artifactId>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencies>

--- a/qa/ensure-clean-db-plugin/pom.xml
+++ b/qa/ensure-clean-db-plugin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>fluxnova-qa</artifactId>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/qa/integration-tests-engine-jakarta/pom.xml
+++ b/qa/integration-tests-engine-jakarta/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/integration-tests-engine-jakarta/pom.xml
+++ b/qa/integration-tests-engine-jakarta/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/integration-tests-engine-jakarta/pom.xml
+++ b/qa/integration-tests-engine-jakarta/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/integration-tests-webapps/integration-tests/pom.xml
+++ b/qa/integration-tests-webapps/integration-tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa-integration-tests-webapps-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   

--- a/qa/integration-tests-webapps/integration-tests/pom.xml
+++ b/qa/integration-tests-webapps/integration-tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa-integration-tests-webapps-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   

--- a/qa/integration-tests-webapps/integration-tests/pom.xml
+++ b/qa/integration-tests-webapps/integration-tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa-integration-tests-webapps-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../</relativePath>
   </parent>
   

--- a/qa/integration-tests-webapps/pom.xml
+++ b/qa/integration-tests-webapps/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/integration-tests-webapps/pom.xml
+++ b/qa/integration-tests-webapps/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/integration-tests-webapps/pom.xml
+++ b/qa/integration-tests-webapps/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/qa/integration-tests-webapps/shared-engine/pom.xml
+++ b/qa/integration-tests-webapps/shared-engine/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa-integration-tests-webapps-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/qa/integration-tests-webapps/shared-engine/pom.xml
+++ b/qa/integration-tests-webapps/shared-engine/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa-integration-tests-webapps-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/qa/integration-tests-webapps/shared-engine/pom.xml
+++ b/qa/integration-tests-webapps/shared-engine/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa-integration-tests-webapps-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/qa/large-data-tests/pom.xml
+++ b/qa/large-data-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/qa/large-data-tests/pom.xml
+++ b/qa/large-data-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/qa/large-data-tests/pom.xml
+++ b/qa/large-data-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/qa/performance-tests-engine/pom.xml
+++ b/qa/performance-tests-engine/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/performance-tests-engine/pom.xml
+++ b/qa/performance-tests-engine/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/qa/performance-tests-engine/pom.xml
+++ b/qa/performance-tests-engine/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/qa/tomcat-runtime/pom.xml
+++ b/qa/tomcat-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/qa/tomcat-runtime/pom.xml
+++ b/qa/tomcat-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencies>

--- a/qa/tomcat-runtime/pom.xml
+++ b/qa/tomcat-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/qa/tomcat9-runtime/pom.xml
+++ b/qa/tomcat9-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/qa/tomcat9-runtime/pom.xml
+++ b/qa/tomcat9-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencies>

--- a/qa/tomcat9-runtime/pom.xml
+++ b/qa/tomcat9-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/qa/wildfly-runtime/pom.xml
+++ b/qa/wildfly-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
 

--- a/qa/wildfly-runtime/pom.xml
+++ b/qa/wildfly-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
 

--- a/qa/wildfly-runtime/pom.xml
+++ b/qa/wildfly-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
 

--- a/qa/wildfly26-runtime/pom.xml
+++ b/qa/wildfly26-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/qa/wildfly26-runtime/pom.xml
+++ b/qa/wildfly26-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencies>

--- a/qa/wildfly26-runtime/pom.xml
+++ b/qa/wildfly26-runtime/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.qa</groupId>
     <artifactId>fluxnova-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/quarkus-extension/engine/deployment/pom.xml
+++ b/quarkus-extension/engine/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.quarkus</groupId>
     <artifactId>fluxnova-bpm-quarkus-engine-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-bpm-quarkus-engine-deployment</artifactId>

--- a/quarkus-extension/engine/deployment/pom.xml
+++ b/quarkus-extension/engine/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.quarkus</groupId>
     <artifactId>fluxnova-bpm-quarkus-engine-parent</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpm-quarkus-engine-deployment</artifactId>

--- a/quarkus-extension/engine/deployment/pom.xml
+++ b/quarkus-extension/engine/deployment/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.quarkus</groupId>
     <artifactId>fluxnova-bpm-quarkus-engine-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpm-quarkus-engine-deployment</artifactId>

--- a/quarkus-extension/engine/pom.xml
+++ b/quarkus-extension/engine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>fluxnova-bpm-quarkus-parent</artifactId>
     <groupId>org.finos.fluxnova.bpm.quarkus</groupId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpm-quarkus-engine-parent</artifactId>

--- a/quarkus-extension/engine/pom.xml
+++ b/quarkus-extension/engine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>fluxnova-bpm-quarkus-parent</artifactId>
     <groupId>org.finos.fluxnova.bpm.quarkus</groupId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-bpm-quarkus-engine-parent</artifactId>

--- a/quarkus-extension/engine/pom.xml
+++ b/quarkus-extension/engine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>fluxnova-bpm-quarkus-parent</artifactId>
     <groupId>org.finos.fluxnova.bpm.quarkus</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpm-quarkus-engine-parent</artifactId>

--- a/quarkus-extension/engine/qa/pom.xml
+++ b/quarkus-extension/engine/qa/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.quarkus</groupId>
     <artifactId>fluxnova-bpm-quarkus-engine-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus-extension/engine/qa/pom.xml
+++ b/quarkus-extension/engine/qa/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.quarkus</groupId>
     <artifactId>fluxnova-bpm-quarkus-engine-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus-extension/engine/qa/pom.xml
+++ b/quarkus-extension/engine/qa/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.quarkus</groupId>
     <artifactId>fluxnova-bpm-quarkus-engine-parent</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/quarkus-extension/engine/runtime/pom.xml
+++ b/quarkus-extension/engine/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.quarkus</groupId>
     <artifactId>fluxnova-bpm-quarkus-engine-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-bpm-quarkus-engine</artifactId>

--- a/quarkus-extension/engine/runtime/pom.xml
+++ b/quarkus-extension/engine/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.quarkus</groupId>
     <artifactId>fluxnova-bpm-quarkus-engine-parent</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpm-quarkus-engine</artifactId>

--- a/quarkus-extension/engine/runtime/pom.xml
+++ b/quarkus-extension/engine/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.quarkus</groupId>
     <artifactId>fluxnova-bpm-quarkus-engine-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpm-quarkus-engine</artifactId>

--- a/quarkus-extension/pom.xml
+++ b/quarkus-extension/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-bpm-quarkus-parent</artifactId>

--- a/quarkus-extension/pom.xml
+++ b/quarkus-extension/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpm-quarkus-parent</artifactId>

--- a/quarkus-extension/pom.xml
+++ b/quarkus-extension/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-bpm-quarkus-parent</artifactId>

--- a/spin/bom/pom.xml
+++ b/spin/bom/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <groupId>org.finos.fluxnova.spin</groupId>
   <artifactId>fluxnova-spin-bom</artifactId>
   <name>fluxnova spin - bom</name>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>2.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <dependencyManagement>

--- a/spin/bom/pom.xml
+++ b/spin/bom/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <groupId>org.finos.fluxnova.spin</groupId>
   <artifactId>fluxnova-spin-bom</artifactId>
   <name>fluxnova spin - bom</name>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.1</version>
   <packaging>pom</packaging>
 
   <dependencyManagement>

--- a/spin/bom/pom.xml
+++ b/spin/bom/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <groupId>org.finos.fluxnova.spin</groupId>
   <artifactId>fluxnova-spin-bom</artifactId>
   <name>fluxnova spin - bom</name>
-  <version>2.0.1</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <dependencyManagement>

--- a/spin/core/pom.xml
+++ b/spin/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-spin-core</artifactId>

--- a/spin/core/pom.xml
+++ b/spin/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-spin-core</artifactId>

--- a/spin/core/pom.xml
+++ b/spin/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-spin-core</artifactId>

--- a/spin/dataformat-all/pom.xml
+++ b/spin/dataformat-all/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-spin-dataformat-all</artifactId>

--- a/spin/dataformat-all/pom.xml
+++ b/spin/dataformat-all/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-spin-dataformat-all</artifactId>

--- a/spin/dataformat-all/pom.xml
+++ b/spin/dataformat-all/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-spin-dataformat-all</artifactId>

--- a/spin/dataformat-json-jackson/pom.xml
+++ b/spin/dataformat-json-jackson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-spin-dataformat-json-jackson</artifactId>

--- a/spin/dataformat-json-jackson/pom.xml
+++ b/spin/dataformat-json-jackson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-spin-dataformat-json-jackson</artifactId>

--- a/spin/dataformat-json-jackson/pom.xml
+++ b/spin/dataformat-json-jackson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-spin-dataformat-json-jackson</artifactId>

--- a/spin/dataformat-xml-dom-jakarta/pom.xml
+++ b/spin/dataformat-xml-dom-jakarta/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-spin-dataformat-xml-dom-jakarta</artifactId>

--- a/spin/dataformat-xml-dom-jakarta/pom.xml
+++ b/spin/dataformat-xml-dom-jakarta/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-spin-dataformat-xml-dom-jakarta</artifactId>

--- a/spin/dataformat-xml-dom-jakarta/pom.xml
+++ b/spin/dataformat-xml-dom-jakarta/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-spin-dataformat-xml-dom-jakarta</artifactId>

--- a/spin/dataformat-xml-dom/pom.xml
+++ b/spin/dataformat-xml-dom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-spin-dataformat-xml-dom</artifactId>

--- a/spin/dataformat-xml-dom/pom.xml
+++ b/spin/dataformat-xml-dom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-spin-dataformat-xml-dom</artifactId>

--- a/spin/dataformat-xml-dom/pom.xml
+++ b/spin/dataformat-xml-dom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.spin</groupId>
     <artifactId>fluxnova-spin-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-spin-dataformat-xml-dom</artifactId>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.spin</groupId>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.spin</groupId>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-parent</artifactId>
     <relativePath>../parent</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.spin</groupId>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>

--- a/spring-boot-starter/starter-client/spring-boot/pom.xml
+++ b/spring-boot-starter/starter-client/spring-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spring-boot-starter/starter-client/spring-boot/pom.xml
+++ b/spring-boot-starter/starter-client/spring-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spring-boot-starter/starter-client/spring-boot/pom.xml
+++ b/spring-boot-starter/starter-client/spring-boot/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spring-boot-starter/starter-client/spring/pom.xml
+++ b/spring-boot-starter/starter-client/spring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spring-boot-starter/starter-client/spring/pom.xml
+++ b/spring-boot-starter/starter-client/spring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spring-boot-starter/starter-client/spring/pom.xml
+++ b/spring-boot-starter/starter-client/spring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/spring-boot-starter/starter-qa/integration-test-liquibase/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-liquibase/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>qa-liquibase</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-liquibase/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-liquibase/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-liquibase</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-liquibase/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-liquibase/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-liquibase</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-plugins</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-plugins</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-plugins</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-plugins-spin</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-plugins-spin-dataformat-all</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-plugins-spin</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-plugins-spin-dataformat-all</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-plugins-spin</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>qa-plugins-spin-dataformat-all</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-json-jackson/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-json-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-plugins-spin</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-plugins-spin-dataformat-json-jackson</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-json-jackson/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-json-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-plugins-spin</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-plugins-spin-dataformat-json-jackson</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-json-jackson/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-json-jackson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-plugins-spin</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>qa-plugins-spin-dataformat-json-jackson</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-request-scope/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-request-scope/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>qa-request-scope</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-request-scope/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-request-scope/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-request-scope</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-request-scope/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-request-scope/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-request-scope</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-simple/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-simple/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-simple</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-simple/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-simple/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-simple</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-simple/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-simple/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>qa-simple</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/invoice-example/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/invoice-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-webapp</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>qa-webapp-invoice-example</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/invoice-example/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/invoice-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-webapp</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-webapp-invoice-example</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/invoice-example/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/invoice-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-webapp</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-webapp-invoice-example</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-qa</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-webapp</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-webapp-ce-runtime</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-webapp</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>qa-webapp-ce-runtime</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>qa-webapp</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>qa-webapp-ce-runtime</artifactId>

--- a/spring-boot-starter/starter-qa/pom.xml
+++ b/spring-boot-starter/starter-qa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/pom.xml
+++ b/spring-boot-starter/starter-qa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-qa/pom.xml
+++ b/spring-boot-starter/starter-qa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/spring-boot-starter/starter-rest/pom.xml
+++ b/spring-boot-starter/starter-rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-rest/pom.xml
+++ b/spring-boot-starter/starter-rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-rest/pom.xml
+++ b/spring-boot-starter/starter-rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-security/pom.xml
+++ b/spring-boot-starter/starter-security/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-security/pom.xml
+++ b/spring-boot-starter/starter-security/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-security/pom.xml
+++ b/spring-boot-starter/starter-security/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-test/pom.xml
+++ b/spring-boot-starter/starter-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-test/pom.xml
+++ b/spring-boot-starter/starter-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-test/pom.xml
+++ b/spring-boot-starter/starter-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-webapp-core/pom.xml
+++ b/spring-boot-starter/starter-webapp-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-webapp-core/pom.xml
+++ b/spring-boot-starter/starter-webapp-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-webapp-core/pom.xml
+++ b/spring-boot-starter/starter-webapp-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-webapp/pom.xml
+++ b/spring-boot-starter/starter-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-webapp/pom.xml
+++ b/spring-boot-starter/starter-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter-webapp/pom.xml
+++ b/spring-boot-starter/starter-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.springboot.project</groupId>
     <artifactId>fluxnova-bpm-spring-boot-starter-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.finos.fluxnova.bpm.springboot</groupId>

--- a/test-utils/archunit/pom.xml
+++ b/test-utils/archunit/pom.xml
@@ -9,7 +9,7 @@
         <groupId>org.finos.fluxnova.bpm</groupId>
         <artifactId>fluxnova-database-settings</artifactId>
         <relativePath>../../database</relativePath>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
 
     <dependencies>

--- a/test-utils/archunit/pom.xml
+++ b/test-utils/archunit/pom.xml
@@ -9,7 +9,7 @@
         <groupId>org.finos.fluxnova.bpm</groupId>
         <artifactId>fluxnova-database-settings</artifactId>
         <relativePath>../../database</relativePath>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/test-utils/archunit/pom.xml
+++ b/test-utils/archunit/pom.xml
@@ -9,7 +9,7 @@
         <groupId>org.finos.fluxnova.bpm</groupId>
         <artifactId>fluxnova-database-settings</artifactId>
         <relativePath>../../database</relativePath>
-        <version>2.0.1</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/test-utils/assert/core/pom.xml
+++ b/test-utils/assert/core/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-bpm-assert-root</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
   
   <dependencies>

--- a/test-utils/assert/core/pom.xml
+++ b/test-utils/assert/core/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-bpm-assert-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
   
   <dependencies>

--- a/test-utils/assert/core/pom.xml
+++ b/test-utils/assert/core/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-bpm-assert-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   
   <dependencies>

--- a/test-utils/assert/pom.xml
+++ b/test-utils/assert/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/test-utils/assert/pom.xml
+++ b/test-utils/assert/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/test-utils/assert/pom.xml
+++ b/test-utils/assert/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencyManagement>

--- a/test-utils/assert/qa/pom.xml
+++ b/test-utils/assert/qa/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-bpm-assert-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <dependencies>

--- a/test-utils/assert/qa/pom.xml
+++ b/test-utils/assert/qa/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-bpm-assert-root</artifactId>
     <relativePath>../</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/test-utils/assert/qa/pom.xml
+++ b/test-utils/assert/qa/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-bpm-assert-root</artifactId>
     <relativePath>../</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/test-utils/junit5-extension-dmn/pom.xml
+++ b/test-utils/junit5-extension-dmn/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../../database</relativePath>
   </parent>
 

--- a/test-utils/junit5-extension-dmn/pom.xml
+++ b/test-utils/junit5-extension-dmn/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../../database</relativePath>
   </parent>
 

--- a/test-utils/junit5-extension-dmn/pom.xml
+++ b/test-utils/junit5-extension-dmn/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../../database</relativePath>
   </parent>
 

--- a/test-utils/junit5-extension/pom.xml
+++ b/test-utils/junit5-extension/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/test-utils/junit5-extension/pom.xml
+++ b/test-utils/junit5-extension/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/test-utils/junit5-extension/pom.xml
+++ b/test-utils/junit5-extension/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <properties>

--- a/test-utils/testcontainers/pom.xml
+++ b/test-utils/testcontainers/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-test-utils-testcontainers</artifactId>

--- a/test-utils/testcontainers/pom.xml
+++ b/test-utils/testcontainers/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>fluxnova-test-utils-testcontainers</artifactId>

--- a/test-utils/testcontainers/pom.xml
+++ b/test-utils/testcontainers/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
     <relativePath>../../database</relativePath>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
   </parent>
 
   <artifactId>fluxnova-test-utils-testcontainers</artifactId>

--- a/webapps/assembly-jakarta/pom.xml
+++ b/webapps/assembly-jakarta/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.webapp</groupId>
     <artifactId>fluxnova-webapp-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/webapps/assembly-jakarta/pom.xml
+++ b/webapps/assembly-jakarta/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.webapp</groupId>
     <artifactId>fluxnova-webapp-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/webapps/assembly-jakarta/pom.xml
+++ b/webapps/assembly-jakarta/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.webapp</groupId>
     <artifactId>fluxnova-webapp-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.webapp</groupId>
     <artifactId>fluxnova-webapp-root</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.webapp</groupId>
     <artifactId>fluxnova-webapp-root</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm.webapp</groupId>
     <artifactId>fluxnova-webapp-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../database</relativePath>
   </parent>
 

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../database</relativePath>
   </parent>
 

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.finos.fluxnova.bpm</groupId>
     <artifactId>fluxnova-database-settings</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <relativePath>../database</relativePath>
   </parent>
 


### PR DESCRIPTION
…ron expression parsing

- Updated CronTimer.java to use CronType.QUARTZ instead of CronType.SPRING53 to ensure compatibility and correct parsing of cron expressions
- Bumped all parent/child project versions from 3.0.0-SNAPSHOT to 2.0.1-SNAPSHOT
- This PR is created to create hotfix. Do not update the PR or merge to MAIN branch.