### PR TITLE
ad hoc - fix completion condition not respecting cancelRemainingInstance property

### DIFF
--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/bpmn/behavior/AdHocSubProcessActivityBehavior.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/bpmn/behavior/AdHocSubProcessActivityBehavior.java
@@ -15,7 +15,7 @@ import org.finos.fluxnova.bpm.engine.impl.bpmn.parser.BpmnParse;
 import org.finos.fluxnova.bpm.engine.impl.el.Expression;
 import org.finos.fluxnova.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.finos.fluxnova.bpm.engine.impl.pvm.delegate.ActivityExecution;
-import org.finos.fluxnova.bpm.engine.impl.pvm.delegate.CompositeActivityBehavior;
+import org.finos.fluxnova.bpm.engine.impl.pvm.delegate.AdHocCompositeActivityBehavior;
 import org.finos.fluxnova.bpm.engine.impl.pvm.process.ActivityImpl;
 
 /**
@@ -36,7 +36,7 @@ import org.finos.fluxnova.bpm.engine.impl.pvm.process.ActivityImpl;
  * required.
  *
  */
-public class AdHocSubProcessActivityBehavior extends AbstractBpmnActivityBehavior implements CompositeActivityBehavior {
+public class AdHocSubProcessActivityBehavior extends AbstractBpmnActivityBehavior implements AdHocCompositeActivityBehavior {
 
   protected static final String VARIABLE_AD_HOC_ACTIVITY_STARTED = "adHocActivityStarted";
 
@@ -75,8 +75,8 @@ public class AdHocSubProcessActivityBehavior extends AbstractBpmnActivityBehavio
     // Evaluate before pruning so ad-hoc scope metadata and active children are still intact.
     evaluateCompletionCondition(scopeExecution, adHocScopeActivity);
 
-    // If completion handling moved execution out of the ad-hoc scope, stop here.
-    if (scopeExecution.getActivity() != adHocScopeActivity) {
+    // If completion handling moved execution out of the ad-hoc scope or ended it, stop here.
+    if (scopeExecution.getActivity() != adHocScopeActivity || scopeExecution.isEnded()) {
       return;
     }
 
@@ -144,6 +144,39 @@ public class AdHocSubProcessActivityBehavior extends AbstractBpmnActivityBehavio
     }
   }
 
+  /**
+   * Invoked before a direct child execution leaves its activity via an
+   * outgoing transition. Returns {@code true} when the completion condition is
+   * already satisfied and remaining instances are to be canceled, so that the
+   * child execution ends instead of flowing onward — which completes the
+   * subprocess and cancels all remaining activities.
+   */
+  @Override
+  public boolean shouldCompleteOnChildTransition(ActivityExecution scopeExecution) {
+    if (scopeExecution == null) {
+      return false;
+    }
+
+    ActivityImpl scopeActivity = (ActivityImpl) scopeExecution.getActivity();
+    if (!isAdHocScopeActivity(scopeActivity)) {
+      return false;
+    }
+
+    Condition completionCondition = (Condition) scopeActivity
+        .getProperty(BpmnParse.PROPERTYNAME_AD_HOC_COMPLETION_CONDITION);
+    if (completionCondition == null) {
+      return false;
+    }
+
+    boolean cancelRemaining = Boolean.TRUE.equals(
+        scopeActivity.getProperty(BpmnParse.PROPERTYNAME_AD_HOC_CANCEL_REMAINING));
+    if (!cancelRemaining) {
+      return false;
+    }
+
+    return completionCondition.evaluate(scopeExecution, scopeExecution);
+  }
+
   protected boolean isAdHocScopeExecution(ActivityExecution execution) {
     if (execution == null || execution.getActivity() == null) {
       return false;
@@ -169,7 +202,13 @@ public class AdHocSubProcessActivityBehavior extends AbstractBpmnActivityBehavio
     List<ActivityExecution> children = new ArrayList<>(scopeExecution.getExecutions());
     for (ActivityExecution child : children) {
       child.interrupt("adHocCompletionConditionMet");
+      // interrupt only fires the end listeners; the execution must also be removed so
+      // that its variables and tasks are deleted before the ad-hoc scope execution is
+      // destroyed (otherwise tryPruneLastConcurrentChild may move the canceled child's
+      // variables onto the already deleted scope execution -> FK violation on flush)
+      child.remove();
     }
+    scopeExecution.forceUpdate();
   }
 
   protected boolean hasActiveChildExecutions(ActivityExecution scopeExecution) {

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/bpmn/behavior/AdHocSubProcessActivityBehavior.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/bpmn/behavior/AdHocSubProcessActivityBehavior.java
@@ -80,7 +80,6 @@ public class AdHocSubProcessActivityBehavior extends AbstractBpmnActivityBehavio
       return;
     }
 
-    scopeExecution.tryPruneLastConcurrentChild();
     scopeExecution.forceUpdate();
   }
 

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -3403,6 +3403,17 @@ public class BpmnParse extends Parse {
     }
   }
 
+  protected ActivityImpl getAdHocSubProcessScope(ActivityImpl activity) {
+    ScopeImpl flowScope = activity.getFlowScope();
+    if (flowScope instanceof ActivityImpl) {
+      ActivityImpl flowScopeActivity = (ActivityImpl) flowScope;
+      if (ActivityTypes.SUB_PROCESS_AD_HOC.equals(flowScopeActivity.getProperty(BpmnProperties.TYPE.getName()))) {
+        return flowScopeActivity;
+      }
+    }
+    return null;
+  }
+
   /**
    * Parses a boundary timer event. The end-result will be that the given nested
    * activity will get the appropriate {@link ActivityBehavior}.
@@ -4878,17 +4889,21 @@ public class BpmnParse extends Parse {
 
           activity.setIoMapping(inputOutput);
 
-          if (getMultiInstanceScope(activity) == null) {
+          if (getMultiInstanceScope(activity) == null && getAdHocSubProcessScope(activity) == null) {
             // turn activity into a scope (->local, isolated scope for
-            // variables) unless it is a multi instance activity, in that case
-            // this
-            // is not necessary because:
+            // variables) unless it is a multi instance activity or a direct
+            // child of an ad hoc subprocess, in that case this is not necessary
+            // because:
             // A scope is already created for the multi instance body which
             // isolates the local variables from other executions in the same
             // scope, and
             // * parallel: the individual concurrent executions are isolated
             // even if they are not scope themselves
             // * sequential: after each iteration local variables are purged
+            // For an ad hoc subprocess the subprocess scope execution provides
+            // variable isolation, and output-parameter values written by child
+            // tasks must propagate to the subprocess scope (e.g. to satisfy a
+            // completionCondition).
             activity.setScope(true);
           }
         }

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/pvm/delegate/AdHocCompositeActivityBehavior.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/pvm/delegate/AdHocCompositeActivityBehavior.java
@@ -1,0 +1,20 @@
+package org.finos.fluxnova.bpm.engine.impl.pvm.delegate;
+
+/**
+ * Composite behavior of an ad-hoc scope which may complete eagerly while child
+ * executions are still active, e.g. when a completion condition is satisfied.
+ */
+public interface AdHocCompositeActivityBehavior extends CompositeActivityBehavior {
+
+  /**
+   * Invoked before a direct child execution of the ad-hoc scope leaves its
+   * current activity via an outgoing transition. If this returns {@code true},
+   * the child execution is ended instead of taking the transition, which in
+   * turn completes the ad-hoc scope and cancels its remaining children.
+   *
+   * @param scopeExecution scope execution for the activity which defined the behavior
+   * @return {@code true} if the ad-hoc scope should complete instead of
+   *         propagating the child execution along the transition
+   */
+  boolean shouldCompleteOnChildTransition(ActivityExecution scopeExecution);
+}

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/pvm/runtime/PvmExecutionImpl.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/pvm/runtime/PvmExecutionImpl.java
@@ -56,7 +56,9 @@ import org.finos.fluxnova.bpm.engine.impl.pvm.PvmProcessDefinition;
 import org.finos.fluxnova.bpm.engine.impl.pvm.PvmProcessInstance;
 import org.finos.fluxnova.bpm.engine.impl.pvm.PvmScope;
 import org.finos.fluxnova.bpm.engine.impl.pvm.PvmTransition;
+import org.finos.fluxnova.bpm.engine.impl.pvm.delegate.ActivityBehavior;
 import org.finos.fluxnova.bpm.engine.impl.pvm.delegate.ActivityExecution;
+import org.finos.fluxnova.bpm.engine.impl.pvm.delegate.AdHocCompositeActivityBehavior;
 import org.finos.fluxnova.bpm.engine.impl.pvm.delegate.CompositeActivityBehavior;
 import org.finos.fluxnova.bpm.engine.impl.pvm.delegate.ModificationObserverBehavior;
 import org.finos.fluxnova.bpm.engine.impl.pvm.delegate.SignallableActivityBehavior;
@@ -1033,6 +1035,24 @@ public abstract class PvmExecutionImpl extends CoreExecution implements
 
   @Override
   public void leaveActivityViaTransitions(List<PvmTransition> _transitions, List<? extends ActivityExecution> _recyclableExecutions) {
+    // if this is a direct child of an ad-hoc scope whose completion condition is
+    // already satisfied (with cancelRemainingInstances=true), end this execution
+    // instead of taking the transition: the regular end path then completes the
+    // ad-hoc scope and cancels its remaining children
+    if (_transitions != null && !_transitions.isEmpty() && isConcurrent() && !isScope() && getActivity() != null) {
+      ScopeImpl flowScope = getActivity().getFlowScope();
+      if (flowScope instanceof PvmActivity) {
+        ActivityBehavior flowScopeBehavior = ((PvmActivity) flowScope).getActivityBehavior();
+        PvmExecutionImpl scopeExecution = getParent();
+        if (flowScopeBehavior instanceof AdHocCompositeActivityBehavior
+            && scopeExecution != null
+            && ((AdHocCompositeActivityBehavior) flowScopeBehavior).shouldCompleteOnChildTransition(scopeExecution)) {
+          end(false);
+          return;
+        }
+      }
+    }
+
     List<? extends ActivityExecution> recyclableExecutions = Collections.emptyList();
     if (_recyclableExecutions != null) {
       recyclableExecutions = new ArrayList<>(_recyclableExecutions);

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.java
@@ -846,6 +846,196 @@ public class AdHocSubProcessTest extends PluggableProcessEngineTest {
           e.getMessage());
     }
   }
+
+  @Deployment
+  @Test
+  public void testMultiInstanceParallelAdHocSubProcessWithIoMappedTasks() {
+    // regression test: tasks with camunda:inputOutput inside a parallel multi-instance ad hoc subprocess
+    // were failing at process start because the task was marked scope due to its IO mapping, creating a
+    // mismatch between the scope hierarchy and the execution hierarchy
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(
+        "adHocSubProcessMultiInstanceParallelWithIoMappedTasks");
+
+    List<Task> adHocTasks = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskA")
+        .list();
+
+    assertEquals(2, adHocTasks.size());
+
+    for (Task task : adHocTasks) {
+      taskService.complete(task.getId());
+    }
+
+    assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+  }
+
+  @Deployment
+  @Test
+  public void testCompletionConditionCancelsRemainingIoMappedTasks() {
+    // regression test: completing a task with a variable that satisfies the completion condition
+    // while other IO-mapped tasks are still active caused an ACT_FK_VAR_EXE foreign key violation,
+    // because the ad hoc scope execution was deleted while variables still referenced it
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(
+        "adHocSubProcessCompletionConditionWithIoMappedTasks");
+
+    Task taskA = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskA")
+        .singleResult();
+    assertNotNull(taskA);
+
+    // complete Task_A -> flows to Task_B (Task_C still active)
+    taskService.complete(taskA.getId());
+
+    Task taskB = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskB")
+        .singleResult();
+    assertNotNull(taskB);
+
+    // completing Task_B with approved=true satisfies the completion condition,
+    // which cancels the still-active Task_C and leaves the subprocess
+    taskService.complete(taskB.getId(), Collections.singletonMap("approved", true));
+
+    assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+  }
+
+  @Deployment(resources = "org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testCompletionConditionCancelsRemainingIoMappedTasks.bpmn20.xml")
+  @Test
+  public void testCompletionConditionOnMidChainTaskCompletionCancelsRemaining() {
+    // completing a task that has an outgoing sequence flow (taskA -> taskB) with a variable
+    // that satisfies the completion condition must complete the subprocess immediately:
+    // taskB is never created and the still-active taskC is canceled
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(
+        "adHocSubProcessCompletionConditionWithIoMappedTasks");
+
+    Task taskA = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskA")
+        .singleResult();
+    assertNotNull(taskA);
+
+    taskService.complete(taskA.getId(), Collections.singletonMap("approved", true));
+
+    assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+  }
+
+  @Deployment
+  @Test
+  public void testAutoCompleteFalseStillHonorsCompletionCondition() {
+    // with autoComplete=false, an explicit completion condition is still honored:
+    // completing the mid-chain taskA with approved=true completes the subprocess (taskB never created)
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(
+        "adHocSubProcessCompletionConditionAutoCompleteFalse",
+        Collections.singletonMap("approved", false));
+
+    Task taskA = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskA")
+        .singleResult();
+
+    Task taskB = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskB")
+        .singleResult();
+
+    assertNotNull(taskA);
+    assertNotNull(taskB);
+
+    taskService.complete(taskA.getId(), Collections.singletonMap("approved", true));
+
+    assertNull(taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskB")
+        .singleResult());
+
+    assertNotNull(taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskAfter")
+        .singleResult());
+  }
+
+  @Deployment
+  @Test
+  public void testAutoCompleteFalseKeepsScopeOpenAfterActivitiesComplete() {
+    // with autoComplete=false and no completion condition, the scope stays open after all
+    // started activities complete until explicit completion is requested
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("adHocSubProcessAutoCompleteFalse");
+
+    Task taskA = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskA")
+        .singleResult();
+
+    Task taskB = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskB")
+        .singleResult();
+
+    assertNotNull(taskA);
+    assertNotNull(taskB);
+
+    taskService.complete(taskA.getId());
+    taskService.complete(taskB.getId());
+
+    Execution adHocExecution = runtimeService.createExecutionQuery()
+        .processInstanceId(processInstance.getId())
+        .activityId("adHocSubProcess")
+        .singleResult();
+
+    assertNotNull(adHocExecution);
+    assertNull(taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskAfter")
+        .singleResult());
+
+    runtimeService.completeAdHocSubProcess(adHocExecution.getId());
+
+    assertNull(runtimeService.createExecutionQuery()
+        .processInstanceId(processInstance.getId())
+        .activityId("adHocSubProcess")
+        .singleResult());
+
+    assertNotNull(taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskAfter")
+        .singleResult());
+  }
+
+  @Deployment
+  @Test
+  public void testMultiInstanceParallelInputMappedCompletionConditionCompletesPerInstance() {
+    // process-level 'approved' is input-mapped onto each parallel MI instance of the ad hoc
+    // subprocess, so each instance has its own copy: approving inside one instance completes
+    // only that instance (canceling its remaining tasks) and leaves the sibling untouched
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("adHocSubProcessMiInputMappedCompletion");
+
+    List<Task> taskAs = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskA")
+        .list();
+    assertEquals(2, taskAs.size());
+
+    // mid-chain completion: taskA flows to taskB, but approval completes the instance eagerly
+    taskService.complete(taskAs.get(0).getId(), Collections.singletonMap("approved", true));
+
+    List<Task> remaining = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+    // first instance fully gone (its taskC canceled, taskB never created);
+    // second instance untouched with its taskA and taskC
+    assertEquals(2, remaining.size());
+    assertEquals(1, remaining.stream().filter(t -> "taskA".equals(t.getTaskDefinitionKey())).count());
+    assertEquals(1, remaining.stream().filter(t -> "taskC".equals(t.getTaskDefinitionKey())).count());
+
+    // approving the second instance completes the whole process
+    Task secondTaskA = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskA")
+        .singleResult();
+    taskService.complete(secondTaskA.getId(), Collections.singletonMap("approved", true));
+
+    assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+  }
 }
 
 

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.java
@@ -918,6 +918,12 @@ public class AdHocSubProcessTest extends PluggableProcessEngineTest {
 
     taskService.complete(taskA.getId(), Collections.singletonMap("approved", true));
 
+    // eager completion: taskB must never be created (not created-then-canceled)
+    assertNull(taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskB")
+        .singleResult());
+
     assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
   }
 

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.java
@@ -1,5 +1,7 @@
 package org.finos.fluxnova.bpm.engine.test.bpmn.subprocess;
 
+import static org.finos.fluxnova.bpm.engine.test.util.ExecutionAssert.assertThat;
+import static org.finos.fluxnova.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -19,6 +21,7 @@ import org.finos.fluxnova.bpm.engine.runtime.Execution;
 import org.finos.fluxnova.bpm.engine.runtime.ProcessInstance;
 import org.finos.fluxnova.bpm.engine.task.Task;
 import org.finos.fluxnova.bpm.engine.test.Deployment;
+import org.finos.fluxnova.bpm.engine.test.util.ExecutionTree;
 import org.finos.fluxnova.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.junit.Test;
 
@@ -1041,6 +1044,170 @@ public class AdHocSubProcessTest extends PluggableProcessEngineTest {
     taskService.complete(secondTaskA.getId(), Collections.singletonMap("approved", true));
 
     assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
+  }
+
+  /**
+   * When parallel ad-hoc activities drain down to a single remaining one, the ad-hoc
+   * scope must stay a distinct scope execution with the remaining activity running as a
+   * concurrent child. Historically {@code tryPruneLastConcurrentChild()} folded that last
+   * child into the scope execution, which destroyed the parent subprocess scope that
+   * agentic child execution listeners rely on. This test pins the un-pruned tree shape.
+   */
+  @Deployment(resources = "org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testTriggerAdHocActivityAndCompleteSubProcess.bpmn20.xml")
+  @Test
+  public void testLastRemainingActivityKeepsAdHocScopeAsConcurrentParent() {
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("adHocSubProcessBasic");
+
+    Task taskA = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskA")
+        .singleResult();
+
+    taskService.complete(taskA.getId());
+
+    // taskB is now the only remaining ad-hoc activity
+    assertNotNull(taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskB")
+        .singleResult());
+
+    assertAdHocScopeHasSingleConcurrentChild(processInstance, "taskB");
+  }
+
+  /**
+   * A single starter activity runs as a concurrent child of the ad-hoc scope and completes
+   * end-to-end. Note: the historical prune fired only from {@code concurrentChildExecutionEnded}
+   * (when a sibling ended), so a lone starter never triggered it - this case documents the
+   * baseline single-activity invariant rather than discriminating the prune removal.
+   */
+  @Deployment
+  @Test
+  public void testSingleStarterActivityRunsAsConcurrentChildAndCompletes() {
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("adHocSubProcessSingleStarter");
+
+    Task taskA = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskA")
+        .singleResult();
+
+    assertNotNull(taskA);
+
+    assertAdHocScopeHasSingleConcurrentChild(processInstance, "taskA");
+
+    taskService.complete(taskA.getId());
+
+    // the un-pruned single child still completes the subprocess and flows downstream
+    assertNull(runtimeService.createExecutionQuery()
+        .processInstanceId(processInstance.getId())
+        .activityId("adHocSubProcess")
+        .singleResult());
+    assertEquals(0, runtimeService.createExecutionQuery()
+        .processInstanceId(processInstance.getId())
+        .activityId("taskA")
+        .count());
+    assertNotNull(taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskAfter")
+        .singleResult());
+  }
+
+  /**
+   * Draining two parallel activities down to one and then to zero must still auto-complete
+   * the subprocess. With the prune removed, the final activity now ends via
+   * {@code concurrentChildExecutionEnded} with no children left, rather than via the
+   * folded-scope path; this guards that completion path.
+   */
+  @Deployment(resources = "org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testAutoCompleteAttributeTrueAutoCompletesAdHocSubProcess.bpmn20.xml")
+  @Test
+  public void testDrainToSingleConcurrentChildThenAutoCompletes() {
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("adHocSubProcessAutoCompleteAttributeTrue");
+
+    Task taskA = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskA")
+        .singleResult();
+
+    taskService.complete(taskA.getId());
+
+    // one activity left: scope preserved as a distinct concurrent parent
+    assertAdHocScopeHasSingleConcurrentChild(processInstance, "taskB");
+
+    Task taskB = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskB")
+        .singleResult();
+
+    taskService.complete(taskB.getId());
+
+    // last child ends -> subprocess auto-completes, no leaked executions
+    assertNull(runtimeService.createExecutionQuery()
+        .processInstanceId(processInstance.getId())
+        .activityId("adHocSubProcess")
+        .singleResult());
+    assertEquals(0, runtimeService.createExecutionQuery()
+        .processInstanceId(processInstance.getId())
+        .activityId("taskB")
+        .count());
+    assertNotNull(taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskAfter")
+        .singleResult());
+  }
+
+  /**
+   * With a completion condition that is already met but instances preserved
+   * ({@code cancelRemainingInstances=false}), the open scope must keep the single remaining
+   * activity as a concurrent child and defer leaving until that child finishes.
+   */
+  @Deployment(resources = "org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testCompletionConditionDefersUntilActiveActivitiesFinish.bpmn20.xml")
+  @Test
+  public void testDeferredCompletionKeepsSingleConcurrentChild() {
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(
+        "adHocSubProcessWithDeferredCompletion",
+        Collections.singletonMap("approved", false));
+
+    Task taskA = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskA")
+        .singleResult();
+
+    // condition becomes true, but taskB is still active -> scope must stay open
+    taskService.complete(taskA.getId(), Collections.singletonMap("approved", true));
+
+    assertNull(taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskAfter")
+        .singleResult());
+
+    assertAdHocScopeHasSingleConcurrentChild(processInstance, "taskB");
+
+    Task taskB = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskB")
+        .singleResult();
+
+    taskService.complete(taskB.getId());
+
+    assertNotNull(taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId())
+        .taskDefinitionKey("taskAfter")
+        .singleResult());
+  }
+
+  /**
+   * Asserts that the ad-hoc subprocess scope is preserved as a distinct scope execution
+   * whose only child is a concurrent (non-scope) execution at {@code expectedChildActivityId}.
+   * This is exactly the shape that {@code tryPruneLastConcurrentChild()} would have collapsed.
+   */
+  protected void assertAdHocScopeHasSingleConcurrentChild(ProcessInstance processInstance,
+      String expectedChildActivityId) {
+    ExecutionTree executionTree = ExecutionTree.forExecution(processInstance.getId(), processEngine);
+
+    assertThat(executionTree).matches(
+        describeExecutionTree(null).scope()
+            .child("adHocSubProcess").scope()
+              .child(expectedChildActivityId).concurrent().noScope()
+            .done());
   }
 }
 

--- a/engine/src/test/resources/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testAutoCompleteFalseKeepsScopeOpenAfterActivitiesComplete.bpmn20.xml
+++ b/engine/src/test/resources/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testAutoCompleteFalseKeepsScopeOpenAfterActivitiesComplete.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <process id="adHocSubProcessAutoCompleteFalse" isExecutable="true">
+
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="adHocSubProcess" />
+
+    <adHocSubProcess id="adHocSubProcess" fluxnova:autoComplete="false">
+      <extensionElements>
+        <fluxnova:properties>
+          <fluxnova:property name="activeTasksCollection" value="taskA,taskB" />
+        </fluxnova:properties>
+      </extensionElements>
+      <userTask id="taskA" name="Task A" />
+      <userTask id="taskB" name="Task B" />
+    </adHocSubProcess>
+
+    <sequenceFlow id="flow2" sourceRef="adHocSubProcess" targetRef="taskAfter" />
+    <userTask id="taskAfter" name="Task After" />
+    <sequenceFlow id="flow3" sourceRef="taskAfter" targetRef="end" />
+    <endEvent id="end" />
+
+  </process>
+
+</definitions>

--- a/engine/src/test/resources/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testAutoCompleteFalseStillHonorsCompletionCondition.bpmn20.xml
+++ b/engine/src/test/resources/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testAutoCompleteFalseStillHonorsCompletionCondition.bpmn20.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <process id="adHocSubProcessCompletionConditionAutoCompleteFalse" isExecutable="true">
+
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="adHocSubProcess" />
+
+    <adHocSubProcess id="adHocSubProcess" fluxnova:autoComplete="false" cancelRemainingInstances="true">
+      <extensionElements>
+        <fluxnova:properties>
+          <fluxnova:property name="activeTasksCollection" value="taskA,taskB" />
+        </fluxnova:properties>
+      </extensionElements>
+      <userTask id="taskA" name="Task A" />
+      <userTask id="taskB" name="Task B" />
+      <completionCondition>${approved == true}</completionCondition>
+    </adHocSubProcess>
+
+    <sequenceFlow id="flow2" sourceRef="adHocSubProcess" targetRef="taskAfter" />
+    <userTask id="taskAfter" name="Task After" />
+    <sequenceFlow id="flow3" sourceRef="taskAfter" targetRef="end" />
+    <endEvent id="end" />
+
+  </process>
+
+</definitions>

--- a/engine/src/test/resources/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testCompletionConditionCancelsRemainingIoMappedTasks.bpmn20.xml
+++ b/engine/src/test/resources/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testCompletionConditionCancelsRemainingIoMappedTasks.bpmn20.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <process id="adHocSubProcessCompletionConditionWithIoMappedTasks" isExecutable="true">
+
+    <startEvent id="start">
+      <extensionElements>
+        <camunda:executionListener event="start">
+          <camunda:script scriptFormat="javascript">execution.setVariable("approved", false)</camunda:script>
+        </camunda:executionListener>
+      </extensionElements>
+    </startEvent>
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="adHocSubProcess" />
+
+    <adHocSubProcess id="adHocSubProcess" fluxnova:autoComplete="false">
+      <extensionElements>
+        <fluxnova:properties>
+          <fluxnova:property name="activeTasksCollection" value="taskA,taskC" />
+        </fluxnova:properties>
+      </extensionElements>
+
+      <sequenceFlow id="flowAB" sourceRef="taskA" targetRef="taskB" />
+
+      <userTask id="taskA" name="Task A">
+        <extensionElements>
+          <camunda:inputOutput>
+            <camunda:inputParameter name="firstName">Kermit</camunda:inputParameter>
+            <camunda:inputParameter name="lastName">ZeeFrog</camunda:inputParameter>
+            <camunda:outputParameter name="firstName">${firstName}</camunda:outputParameter>
+            <camunda:outputParameter name="lastName">${lastName}</camunda:outputParameter>
+          </camunda:inputOutput>
+        </extensionElements>
+        <outgoing>flowAB</outgoing>
+      </userTask>
+
+      <userTask id="taskB" name="Task B">
+        <incoming>flowAB</incoming>
+      </userTask>
+
+      <userTask id="taskC" name="Task C">
+        <extensionElements>
+          <camunda:inputOutput>
+            <camunda:inputParameter name="firstName">Donald</camunda:inputParameter>
+            <camunda:inputParameter name="lastName">Duck</camunda:inputParameter>
+            <camunda:outputParameter name="firstName">${firstName}</camunda:outputParameter>
+            <camunda:outputParameter name="lastName">${lastName}</camunda:outputParameter>
+          </camunda:inputOutput>
+        </extensionElements>
+      </userTask>
+
+      <completionCondition xsi:type="tFormalExpression">${approved==true}</completionCondition>
+    </adHocSubProcess>
+
+    <sequenceFlow id="flow2" sourceRef="adHocSubProcess" targetRef="end" />
+    <endEvent id="end" />
+
+  </process>
+
+</definitions>

--- a/engine/src/test/resources/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testMultiInstanceParallelAdHocSubProcessWithIoMappedTasks.bpmn20.xml
+++ b/engine/src/test/resources/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testMultiInstanceParallelAdHocSubProcessWithIoMappedTasks.bpmn20.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <process id="adHocSubProcessMultiInstanceParallelWithIoMappedTasks" isExecutable="true">
+
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="adHocSubProcess" />
+
+    <adHocSubProcess id="adHocSubProcess" fluxnova:autoComplete="true">
+      <extensionElements>
+        <fluxnova:properties>
+          <fluxnova:property name="activeTasksCollection" value="taskA" />
+        </fluxnova:properties>
+      </extensionElements>
+
+      <multiInstanceLoopCharacteristics isSequential="false">
+        <loopCardinality>2</loopCardinality>
+      </multiInstanceLoopCharacteristics>
+
+      <userTask id="taskA" name="Task A">
+        <extensionElements>
+          <camunda:inputOutput>
+            <camunda:inputParameter name="firstName">Kermit</camunda:inputParameter>
+            <camunda:outputParameter name="firstName">${firstName}</camunda:outputParameter>
+          </camunda:inputOutput>
+        </extensionElements>
+      </userTask>
+    </adHocSubProcess>
+
+    <sequenceFlow id="flow2" sourceRef="adHocSubProcess" targetRef="end" />
+    <endEvent id="end" />
+
+  </process>
+
+</definitions>

--- a/engine/src/test/resources/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testMultiInstanceParallelInputMappedCompletionConditionCompletesPerInstance.bpmn20.xml
+++ b/engine/src/test/resources/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testMultiInstanceParallelInputMappedCompletionConditionCompletesPerInstance.bpmn20.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <process id="adHocSubProcessMiInputMappedCompletion" isExecutable="true">
+
+    <startEvent id="start">
+      <extensionElements>
+        <camunda:executionListener event="start">
+          <camunda:script scriptFormat="javascript">execution.setVariable("approved", false)</camunda:script>
+        </camunda:executionListener>
+      </extensionElements>
+    </startEvent>
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="adHocSubProcess" />
+
+    <adHocSubProcess id="adHocSubProcess" fluxnova:autoComplete="false">
+      <extensionElements>
+        <fluxnova:properties>
+          <fluxnova:property name="activeTasksCollection" value="taskA,taskC" />
+        </fluxnova:properties>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="approved">${approved}</camunda:inputParameter>
+        </camunda:inputOutput>
+      </extensionElements>
+
+      <multiInstanceLoopCharacteristics isSequential="false">
+        <loopCardinality>2</loopCardinality>
+      </multiInstanceLoopCharacteristics>
+
+      <sequenceFlow id="flowAB" sourceRef="taskA" targetRef="taskB" />
+
+      <userTask id="taskA" name="Task A">
+        <outgoing>flowAB</outgoing>
+      </userTask>
+
+      <userTask id="taskB" name="Task B">
+        <incoming>flowAB</incoming>
+      </userTask>
+
+      <userTask id="taskC" name="Task C" />
+
+      <completionCondition xsi:type="tFormalExpression">${approved==true}</completionCondition>
+    </adHocSubProcess>
+
+    <sequenceFlow id="flow2" sourceRef="adHocSubProcess" targetRef="end" />
+    <endEvent id="end" />
+
+  </process>
+
+</definitions>

--- a/engine/src/test/resources/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testSingleStarterActivityRunsAsConcurrentChildAndCompletes.bpmn20.xml
+++ b/engine/src/test/resources/org/finos/fluxnova/bpm/engine/test/bpmn/subprocess/AdHocSubProcessTest.testSingleStarterActivityRunsAsConcurrentChildAndCompletes.bpmn20.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <process id="adHocSubProcessSingleStarter" isExecutable="true">
+
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="adHocSubProcess" />
+
+    <adHocSubProcess id="adHocSubProcess">
+      <extensionElements>
+        <fluxnova:properties>
+          <fluxnova:property name="activeTasksCollection" value="taskA" />
+        </fluxnova:properties>
+      </extensionElements>
+      <userTask id="taskA" name="Task A" />
+    </adHocSubProcess>
+
+    <sequenceFlow id="flow2" sourceRef="adHocSubProcess" targetRef="taskAfter" />
+    <userTask id="taskAfter" name="Task After" />
+    <sequenceFlow id="flow3" sourceRef="taskAfter" targetRef="end" />
+    <endEvent id="end" />
+
+  </process>
+
+</definitions>


### PR DESCRIPTION
This PR resolves a bug in ad hoc subprocess completion condition evaluation when a task has an outgoing sequence flow.

Closes: https://github.com/finos/fluxnova-bpm-platform/issues/223