### PR TITLE
fix: add missing 2.0_to_3.0 Liquibase upgrade for RESTRICTED_ column

### DIFF
--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/liquibase/camunda-changelog.xml
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/liquibase/camunda-changelog.xml
@@ -179,4 +179,16 @@
     <tagDatabase tag="2.0.0"/>
   </changeSet>
 
+  <changeSet author="Fluxnova" id="2.0-to-3.0">
+    <sqlFile path="upgrade/${db.name}_engine_2.0_to_3.0.sql"
+             encoding="UTF-8"
+             relativeToChangelogFile="true"
+             splitStatements="true"
+             stripComments="true"/>
+  </changeSet>
+
+  <changeSet author="Fluxnova" id="3.0.0-tag">
+    <tagDatabase tag="3.0.0"/>
+  </changeSet>
+
 </databaseChangeLog>

--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/db2_engine_1.0_to_2.0.sql
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/db2_engine_1.0_to_2.0.sql
@@ -16,4 +16,4 @@
 --
 
 insert into ACT_GE_SCHEMA_LOG
-values ('1300', CURRENT_TIMESTAMP, '2.0.0');
+values ('1400', CURRENT_TIMESTAMP, '2.0.0');

--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/db2_engine_2.0_to_3.0.sql
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/db2_engine_2.0_to_3.0.sql
@@ -1,0 +1,16 @@
+--
+-- Copyright 2025 FINOS
+--
+-- The source files in this repository are made available under the Apache License Version 2.0.
+--
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+alter table ACT_RU_VARIABLE add RESTRICTED_ smallint check(RESTRICTED_ in (1,0));
+alter table ACT_HI_VARINST add RESTRICTED_ smallint check(RESTRICTED_ in (1,0));
+
+create index ACT_IDX_VARIABLE_RESTRICTED on ACT_RU_VARIABLE(RESTRICTED_);
+create index ACT_IDX_HI_VARINST_RESTRICTED on ACT_HI_VARINST(RESTRICTED_);
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1500', CURRENT_TIMESTAMP, '3.0.0');

--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/h2_engine_1.0_to_2.0.sql
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/h2_engine_1.0_to_2.0.sql
@@ -16,4 +16,4 @@
 --
 
 insert into ACT_GE_SCHEMA_LOG
-values ('1300', CURRENT_TIMESTAMP, '2.0.0');
+values ('1400', CURRENT_TIMESTAMP, '2.0.0');

--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/h2_engine_2.0_to_3.0.sql
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/h2_engine_2.0_to_3.0.sql
@@ -1,0 +1,16 @@
+--
+-- Copyright 2025 FINOS
+--
+-- The source files in this repository are made available under the Apache License Version 2.0.
+--
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+alter table ACT_RU_VARIABLE add column RESTRICTED_ bit;
+alter table ACT_HI_VARINST add column RESTRICTED_ bit;
+
+create index ACT_IDX_VARIABLE_RESTRICTED on ACT_RU_VARIABLE(RESTRICTED_);
+create index ACT_IDX_HI_VARINST_RESTRICTED on ACT_HI_VARINST(RESTRICTED_);
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1500', CURRENT_TIMESTAMP, '3.0.0');

--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/mssql_engine_1.0_to_2.0.sql
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/mssql_engine_1.0_to_2.0.sql
@@ -16,4 +16,4 @@
 --
 
 insert into ACT_GE_SCHEMA_LOG
-values ('1300', CURRENT_TIMESTAMP, '2.0.0');
+values ('1400', CURRENT_TIMESTAMP, '2.0.0');

--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/mssql_engine_2.0_to_3.0.sql
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/mssql_engine_2.0_to_3.0.sql
@@ -1,0 +1,16 @@
+--
+-- Copyright 2025 FINOS
+--
+-- The source files in this repository are made available under the Apache License Version 2.0.
+--
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+alter table ACT_RU_VARIABLE add RESTRICTED_ tinyint;
+alter table ACT_HI_VARINST add RESTRICTED_ tinyint;
+
+create index ACT_IDX_VARIABLE_RESTRICTED on ACT_RU_VARIABLE(RESTRICTED_);
+create index ACT_IDX_HI_VARINST_RESTRICTED on ACT_HI_VARINST(RESTRICTED_);
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1500', CURRENT_TIMESTAMP, '3.0.0');

--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/mysql_engine_1.0_to_2.0.sql
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/mysql_engine_1.0_to_2.0.sql
@@ -16,4 +16,4 @@
 --
 
 insert into ACT_GE_SCHEMA_LOG
-values ('1300', CURRENT_TIMESTAMP, '2.0.0');
+values ('1400', CURRENT_TIMESTAMP, '2.0.0');

--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/mysql_engine_2.0_to_3.0.sql
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/mysql_engine_2.0_to_3.0.sql
@@ -1,0 +1,16 @@
+--
+-- Copyright 2025 FINOS
+--
+-- The source files in this repository are made available under the Apache License Version 2.0.
+--
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+alter table ACT_RU_VARIABLE add RESTRICTED_ TINYINT;
+alter table ACT_HI_VARINST add RESTRICTED_ TINYINT;
+
+create index ACT_IDX_VARIABLE_RESTRICTED on ACT_RU_VARIABLE(RESTRICTED_);
+create index ACT_IDX_HI_VARINST_RESTRICTED on ACT_HI_VARINST(RESTRICTED_);
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1500', CURRENT_TIMESTAMP, '3.0.0');

--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/oracle_engine_1.0_to_2.0.sql
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/oracle_engine_1.0_to_2.0.sql
@@ -16,4 +16,4 @@
 --
 
 insert into ACT_GE_SCHEMA_LOG
-values ('1300', CURRENT_TIMESTAMP, '2.0.0');
+values ('1400', CURRENT_TIMESTAMP, '2.0.0');

--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/oracle_engine_2.0_to_3.0.sql
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/oracle_engine_2.0_to_3.0.sql
@@ -1,0 +1,16 @@
+--
+-- Copyright 2025 FINOS
+--
+-- The source files in this repository are made available under the Apache License Version 2.0.
+--
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+alter table ACT_RU_VARIABLE add RESTRICTED_ NUMBER(1,0) CHECK (RESTRICTED_ IN (1,0));
+alter table ACT_HI_VARINST add RESTRICTED_ NUMBER(1,0) CHECK (RESTRICTED_ IN (1,0));
+
+create index ACT_IDX_VARIABLE_RESTRICTED on ACT_RU_VARIABLE(RESTRICTED_);
+create index ACT_IDX_HI_VARINST_RESTRICTED on ACT_HI_VARINST(RESTRICTED_);
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1500', CURRENT_TIMESTAMP, '3.0.0');

--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/postgres_engine_1.0_to_2.0.sql
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/postgres_engine_1.0_to_2.0.sql
@@ -16,4 +16,4 @@
 --
 
 insert into ACT_GE_SCHEMA_LOG
-values ('1300', CURRENT_TIMESTAMP, '2.0.0');
+values ('1400', CURRENT_TIMESTAMP, '2.0.0');

--- a/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/postgres_engine_2.0_to_3.0.sql
+++ b/engine/src/main/resources/org/finos/fluxnova/bpm/engine/db/upgrade/postgres_engine_2.0_to_3.0.sql
@@ -1,0 +1,16 @@
+--
+-- Copyright 2025 FINOS
+--
+-- The source files in this repository are made available under the Apache License Version 2.0.
+--
+-- SPDX-License-Identifier: Apache-2.0
+--
+
+alter table ACT_RU_VARIABLE add column RESTRICTED_ boolean;
+alter table ACT_HI_VARINST add column RESTRICTED_ boolean;
+
+create index ACT_IDX_VARIABLE_RESTRICTED on ACT_RU_VARIABLE(RESTRICTED_);
+create index ACT_IDX_HI_VARINST_RESTRICTED on ACT_HI_VARINST(RESTRICTED_);
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1500', CURRENT_TIMESTAMP, '3.0.0');


### PR DESCRIPTION
Adds the missing `2.0_to_3.0` Liquibase migration (`RESTRICTED_` on `ACT_RU_VARIABLE`/`ACT_HI_VARINST` + indexes) for all six dialects and wires it into the changelog.

Also, fixes the duplicate `ACT_GE_SCHEMA_LOG` id `1300` that blocked the changelog. Verified on H2 and Postgres. 

Closes https://github.com/finos/fluxnova-bpm-platform/issues/228