### PR TITLE
Backport security remediation to the 2.0.x release line

### DIFF
--- a/commons/logging/src/main/java/org/finos/fluxnova/commons/logging/BaseLogger.java
+++ b/commons/logging/src/main/java/org/finos/fluxnova/commons/logging/BaseLogger.java
@@ -147,6 +147,16 @@ public abstract class BaseLogger {
   }
 
   /**
+   * Sanitizes formatted log output to prevent CR/LF/TAB log injection.
+   */
+  private static String sanitize(String input) {
+    if (input == null) {
+      return null;
+    }
+    return input.replaceAll("[\r\n\t]", "_");
+  }
+
+  /**
    * Logs a 'TRACE' message
    *
    * @param id              the unique id of this log message
@@ -156,7 +166,14 @@ public abstract class BaseLogger {
   protected void logTrace(String id, String messageTemplate, Object... parameters) {
     if (delegateLogger.isTraceEnabled()) {
       String msg = formatMessageTemplate(id, messageTemplate);
-      delegateLogger.trace(msg, parameters);
+      org.slf4j.helpers.FormattingTuple formatted = MessageFormatter.arrayFormat(msg, parameters);
+      String sanitized = sanitize(formatted.getMessage());
+      Throwable throwable = formatted.getThrowable();
+      if (throwable != null) {
+        delegateLogger.trace(sanitized, throwable);
+      } else {
+        delegateLogger.trace(sanitized);
+      }
     }
   }
 
@@ -170,7 +187,14 @@ public abstract class BaseLogger {
   protected void logDebug(String id, String messageTemplate, Object... parameters) {
     if(delegateLogger.isDebugEnabled()) {
       String msg = formatMessageTemplate(id, messageTemplate);
-      delegateLogger.debug(msg, parameters);
+      org.slf4j.helpers.FormattingTuple formatted = MessageFormatter.arrayFormat(msg, parameters);
+      String sanitized = sanitize(formatted.getMessage());
+      Throwable throwable = formatted.getThrowable();
+      if (throwable != null) {
+        delegateLogger.debug(sanitized, throwable);
+      } else {
+        delegateLogger.debug(sanitized);
+      }
     }
   }
 
@@ -184,7 +208,14 @@ public abstract class BaseLogger {
   protected void logInfo(String id, String messageTemplate, Object... parameters) {
     if(delegateLogger.isInfoEnabled()) {
       String msg = formatMessageTemplate(id, messageTemplate);
-      delegateLogger.info(msg, parameters);
+      org.slf4j.helpers.FormattingTuple formatted = MessageFormatter.arrayFormat(msg, parameters);
+      String sanitized = sanitize(formatted.getMessage());
+      Throwable throwable = formatted.getThrowable();
+      if (throwable != null) {
+        delegateLogger.info(sanitized, throwable);
+      } else {
+        delegateLogger.info(sanitized);
+      }
     }
   }
 
@@ -198,7 +229,14 @@ public abstract class BaseLogger {
   protected void logWarn(String id, String messageTemplate, Object... parameters) {
     if(delegateLogger.isWarnEnabled()) {
       String msg = formatMessageTemplate(id, messageTemplate);
-      delegateLogger.warn(msg, parameters);
+      org.slf4j.helpers.FormattingTuple formatted = MessageFormatter.arrayFormat(msg, parameters);
+      String sanitized = sanitize(formatted.getMessage());
+      Throwable throwable = formatted.getThrowable();
+      if (throwable != null) {
+        delegateLogger.warn(sanitized, throwable);
+      } else {
+        delegateLogger.warn(sanitized);
+      }
     }
   }
 
@@ -212,7 +250,14 @@ public abstract class BaseLogger {
   protected void logError(String id, String messageTemplate, Object... parameters) {
     if(delegateLogger.isErrorEnabled()) {
       String msg = formatMessageTemplate(id, messageTemplate);
-      delegateLogger.error(msg, parameters);
+      org.slf4j.helpers.FormattingTuple formatted = MessageFormatter.arrayFormat(msg, parameters);
+      String sanitized = sanitize(formatted.getMessage());
+      Throwable throwable = formatted.getThrowable();
+      if (throwable != null) {
+        delegateLogger.error(sanitized, throwable);
+      } else {
+        delegateLogger.error(sanitized);
+      }
     }
   }
 

--- a/commons/logging/src/main/java/org/finos/fluxnova/commons/logging/BaseLogger.java
+++ b/commons/logging/src/main/java/org/finos/fluxnova/commons/logging/BaseLogger.java
@@ -147,13 +147,23 @@ public abstract class BaseLogger {
   }
 
   /**
-   * Sanitizes formatted log output to prevent CR/LF/TAB log injection.
+   * Sanitizes log parameters to prevent CR/LF/TAB log injection while preserving
+   * intentional formatting in the trusted message template.
    */
-  private static String sanitize(String input) {
-    if (input == null) {
-      return null;
+  private static Object[] sanitizeParameters(Object[] parameters) {
+    if (parameters == null || parameters.length == 0) {
+      return parameters;
     }
-    return input.replaceAll("[\r\n\t]", "_");
+
+    Object[] sanitizedParameters = parameters.clone();
+    for (int i = 0; i < sanitizedParameters.length; i++) {
+      Object parameter = sanitizedParameters[i];
+      if (parameter instanceof CharSequence) {
+        sanitizedParameters[i] = parameter.toString().replaceAll("[\r\n\t]", "_");
+      }
+    }
+
+    return sanitizedParameters;
   }
 
   /**
@@ -166,14 +176,7 @@ public abstract class BaseLogger {
   protected void logTrace(String id, String messageTemplate, Object... parameters) {
     if (delegateLogger.isTraceEnabled()) {
       String msg = formatMessageTemplate(id, messageTemplate);
-      org.slf4j.helpers.FormattingTuple formatted = MessageFormatter.arrayFormat(msg, parameters);
-      String sanitized = sanitize(formatted.getMessage());
-      Throwable throwable = formatted.getThrowable();
-      if (throwable != null) {
-        delegateLogger.trace(sanitized, throwable);
-      } else {
-        delegateLogger.trace(sanitized);
-      }
+      delegateLogger.trace(msg, sanitizeParameters(parameters));
     }
   }
 
@@ -187,14 +190,7 @@ public abstract class BaseLogger {
   protected void logDebug(String id, String messageTemplate, Object... parameters) {
     if(delegateLogger.isDebugEnabled()) {
       String msg = formatMessageTemplate(id, messageTemplate);
-      org.slf4j.helpers.FormattingTuple formatted = MessageFormatter.arrayFormat(msg, parameters);
-      String sanitized = sanitize(formatted.getMessage());
-      Throwable throwable = formatted.getThrowable();
-      if (throwable != null) {
-        delegateLogger.debug(sanitized, throwable);
-      } else {
-        delegateLogger.debug(sanitized);
-      }
+      delegateLogger.debug(msg, sanitizeParameters(parameters));
     }
   }
 
@@ -208,14 +204,7 @@ public abstract class BaseLogger {
   protected void logInfo(String id, String messageTemplate, Object... parameters) {
     if(delegateLogger.isInfoEnabled()) {
       String msg = formatMessageTemplate(id, messageTemplate);
-      org.slf4j.helpers.FormattingTuple formatted = MessageFormatter.arrayFormat(msg, parameters);
-      String sanitized = sanitize(formatted.getMessage());
-      Throwable throwable = formatted.getThrowable();
-      if (throwable != null) {
-        delegateLogger.info(sanitized, throwable);
-      } else {
-        delegateLogger.info(sanitized);
-      }
+      delegateLogger.info(msg, sanitizeParameters(parameters));
     }
   }
 
@@ -229,14 +218,7 @@ public abstract class BaseLogger {
   protected void logWarn(String id, String messageTemplate, Object... parameters) {
     if(delegateLogger.isWarnEnabled()) {
       String msg = formatMessageTemplate(id, messageTemplate);
-      org.slf4j.helpers.FormattingTuple formatted = MessageFormatter.arrayFormat(msg, parameters);
-      String sanitized = sanitize(formatted.getMessage());
-      Throwable throwable = formatted.getThrowable();
-      if (throwable != null) {
-        delegateLogger.warn(sanitized, throwable);
-      } else {
-        delegateLogger.warn(sanitized);
-      }
+      delegateLogger.warn(msg, sanitizeParameters(parameters));
     }
   }
 
@@ -250,14 +232,7 @@ public abstract class BaseLogger {
   protected void logError(String id, String messageTemplate, Object... parameters) {
     if(delegateLogger.isErrorEnabled()) {
       String msg = formatMessageTemplate(id, messageTemplate);
-      org.slf4j.helpers.FormattingTuple formatted = MessageFormatter.arrayFormat(msg, parameters);
-      String sanitized = sanitize(formatted.getMessage());
-      Throwable throwable = formatted.getThrowable();
-      if (throwable != null) {
-        delegateLogger.error(sanitized, throwable);
-      } else {
-        delegateLogger.error(sanitized);
-      }
+      delegateLogger.error(msg, sanitizeParameters(parameters));
     }
   }
 
@@ -322,3 +297,4 @@ public abstract class BaseLogger {
   }
 
 }
+

--- a/commons/logging/src/test/java/org/finos/fluxnova/commons/logging/BaseLoggerSecurityTest.java
+++ b/commons/logging/src/test/java/org/finos/fluxnova/commons/logging/BaseLoggerSecurityTest.java
@@ -23,12 +23,25 @@ public class BaseLoggerSecurityTest {
   }
 
   @Test
-  public void shouldSanitizeFormattedLogParameters() {
+  public void shouldSanitizeStringLogParameters() {
     when(delegate.isInfoEnabled()).thenReturn(true);
 
     logger.logInfo("01", "User input: {}", "first\r\nsecond\tthird");
 
-    verify(delegate).info("TEST-0101 User input: first__second_third");
+    verify(delegate).info(
+        "TEST-0101 User input: {}",
+        new Object[] { "first__second_third" });
+  }
+
+  @Test
+  public void shouldPreserveFormattingInMessageTemplate() {
+    when(delegate.isInfoEnabled()).thenReturn(true);
+
+    logger.logInfo("02", "Deployment summary:\n\t{}", "model.bpmn");
+
+    verify(delegate).info(
+        "TEST-0102 Deployment summary:\n\t{}",
+        new Object[] { "model.bpmn" });
   }
 
   @Test
@@ -36,8 +49,11 @@ public class BaseLoggerSecurityTest {
     when(delegate.isErrorEnabled()).thenReturn(true);
     RuntimeException failure = new RuntimeException("failure");
 
-    logger.logError("02", "Failed for {}", "bad\nvalue", failure);
+    logger.logError("03", "Failed for {}", "bad\nvalue", failure);
 
-    verify(delegate).error("TEST-0102 Failed for bad_value", failure);
+    verify(delegate).error(
+        "TEST-0103 Failed for {}",
+        new Object[] { "bad_value", failure });
   }
 }
+

--- a/commons/logging/src/test/java/org/finos/fluxnova/commons/logging/BaseLoggerSecurityTest.java
+++ b/commons/logging/src/test/java/org/finos/fluxnova/commons/logging/BaseLoggerSecurityTest.java
@@ -1,0 +1,43 @@
+package org.finos.fluxnova.commons.logging;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+public class BaseLoggerSecurityTest {
+
+  private ExampleLogger logger;
+  private Logger delegate;
+
+  @Before
+  public void setUp() {
+    logger = new ExampleLogger();
+    logger.projectCode = ExampleLogger.PROJECT_CODE;
+    logger.componentId = ExampleLogger.COMPONENT_ID;
+    delegate = mock(Logger.class);
+    logger.delegateLogger = delegate;
+  }
+
+  @Test
+  public void shouldSanitizeFormattedLogParameters() {
+    when(delegate.isInfoEnabled()).thenReturn(true);
+
+    logger.logInfo("01", "User input: {}", "first\r\nsecond\tthird");
+
+    verify(delegate).info("TEST-0101 User input: first__second_third");
+  }
+
+  @Test
+  public void shouldPreserveTrailingThrowable() {
+    when(delegate.isErrorEnabled()).thenReturn(true);
+    RuntimeException failure = new RuntimeException("failure");
+
+    logger.logError("02", "Failed for {}", "bad\nvalue", failure);
+
+    verify(delegate).error("TEST-0102 Failed for bad_value", failure);
+  }
+}

--- a/engine/src/main/java/org/finos/fluxnova/bpm/container/impl/deployment/DeployProcessArchiveStep.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/container/impl/deployment/DeployProcessArchiveStep.java
@@ -43,7 +43,6 @@ import org.finos.fluxnova.bpm.engine.RepositoryService;
 import org.finos.fluxnova.bpm.engine.impl.ProcessEngineLogger;
 import org.finos.fluxnova.bpm.engine.impl.util.IoUtil;
 import org.finos.fluxnova.bpm.engine.impl.util.StringUtil;
-import org.finos.fluxnova.bpm.engine.impl.util.ReflectUtil;
 import org.finos.fluxnova.bpm.engine.repository.ProcessApplicationDeployment;
 import org.finos.fluxnova.bpm.engine.repository.ProcessApplicationDeploymentBuilder;
 import org.finos.fluxnova.bpm.engine.repository.ResumePreviousBy;
@@ -89,7 +88,15 @@ public class DeployProcessArchiveStep extends DeploymentOperationStep {
     // add all processes listed in the processes.xml
     List<String> listedProcessResources = processArchive.getProcessResourceNames();
     for (String processResource : listedProcessResources) {
-      ReflectUtil.validateResourceName(processResource);
+      if (processResource == null) {
+        throw new IllegalArgumentException("Process resource name must not be null.");
+      }
+      String normalizedResource = processResource.replace('\\', '/');
+      if (normalizedResource.contains("../") || normalizedResource.contains("./")
+          || normalizedResource.equals("..") || normalizedResource.equals(".")) {
+        throw new IllegalArgumentException(
+            "Path traversal detected in process resource name: " + processResource);
+      }
       InputStream resourceAsStream = null;
       try {
         resourceAsStream = processApplicationClassloader.getResourceAsStream(processResource);

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/DynamicExecutableScript.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/DynamicExecutableScript.java
@@ -32,6 +32,8 @@ import org.finos.fluxnova.bpm.engine.delegate.VariableScope;
  */
 public abstract class DynamicExecutableScript extends ExecutableScript {
 
+  private static final int MAX_DYNAMIC_SCRIPT_LENGTH = 1_000_000;
+
   protected final Expression scriptExpression;
 
   protected DynamicExecutableScript(Expression scriptExpression, String language) {
@@ -43,6 +45,17 @@ public abstract class DynamicExecutableScript extends ExecutableScript {
     String source = getScriptSource(variableScope);
     if (source == null) {
       throw new ScriptEvaluationException("Script source must not be null", null);
+    }
+    if (source.length() > MAX_DYNAMIC_SCRIPT_LENGTH) {
+      String activityIdMessage = getActivityIdExceptionMessage(variableScope);
+      throw new ScriptEvaluationException("Unable to evaluate script" + activityIdMessage
+          + ": script source length (" + source.length() + " chars) exceeds the maximum allowed "
+          + MAX_DYNAMIC_SCRIPT_LENGTH + " characters.", null);
+    }
+    if (source.indexOf('\0') >= 0) {
+      String activityIdMessage = getActivityIdExceptionMessage(variableScope);
+      throw new ScriptEvaluationException("Unable to evaluate script" + activityIdMessage
+          + ": script source contains illegal null bytes.", null);
     }
     try {
         return ScriptEvaluationUtil.evaluate(scriptEngine, source, bindings);

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/SourceExecutableScript.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/SourceExecutableScript.java
@@ -53,6 +53,11 @@ public class SourceExecutableScript extends CompiledExecutableScript {
 
   @Override
   public Object evaluate(ScriptEngine engine, VariableScope variableScope, Bindings bindings) {
+    if (scriptSource != null && scriptSource.indexOf('\0') >= 0) {
+      String activityIdMessage = getActivityIdExceptionMessage(variableScope);
+      throw new ScriptEvaluationException("Unable to evaluate script" + activityIdMessage
+          + ": script source contains illegal null bytes.", null);
+    }
     if (shouldBeCompiled) {
       compileScript(engine);
     }

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/util/ReflectUtil.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/util/ReflectUtil.java
@@ -122,24 +122,26 @@ public abstract class ReflectUtil {
   }
 
   /**
-   * Validates that a resource name does not contain path traversal sequences (CWE-73 fix).
-   * Throws ProcessEngineException if the name is null or contains '..' segments.
+   * Validates a classloader resource name before it is passed to a classloader.
    */
   public static void validateResourceName(String name) {
     if (name == null) {
       throw new ProcessEngineException("Resource name must not be null");
     }
-    // Normalize separators and check for path traversal sequences
     String normalized = name.replace('\\', '/');
-    for (String segment : normalized.split("/")) {
-      if ("..".equals(segment)) {
-        throw new ProcessEngineException(
-            "Resource name contains illegal path traversal sequence: " + name);
-      }
+    if (normalized.startsWith("/")
+        || normalized.contains("../")
+        || normalized.contains("./")
+        || normalized.endsWith("..")
+        || normalized.equals("..")
+        || normalized.equals(".")) {
+      throw new ProcessEngineException(
+          "Invalid resource name; path traversal is not allowed: " + name);
     }
   }
 
   public static InputStream getResourceAsStream(String name) {
+    // Validate before passing the resource name to any classloader.
     validateResourceName(name);
     InputStream resourceStream = null;
     ClassLoader classLoader = getCustomClassLoader();
@@ -161,6 +163,7 @@ public abstract class ReflectUtil {
    }
 
    public static URL getResource(String name) {
+     // Validate before passing the resource name to any classloader.
      validateResourceName(name);
      URL url = null;
      ClassLoader classLoader = getCustomClassLoader();

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/scripting/ExecutableScriptSecurityTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/scripting/ExecutableScriptSecurityTest.java
@@ -1,0 +1,73 @@
+package org.finos.fluxnova.bpm.engine.impl.scripting;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import javax.script.Bindings;
+import javax.script.ScriptEngine;
+
+import org.finos.fluxnova.bpm.engine.ScriptEvaluationException;
+import org.finos.fluxnova.bpm.engine.delegate.Expression;
+import org.finos.fluxnova.bpm.engine.delegate.VariableScope;
+import org.junit.Test;
+
+public class ExecutableScriptSecurityTest {
+
+  private final ScriptEngine engine = mock(ScriptEngine.class);
+  private final VariableScope variableScope = mock(VariableScope.class);
+  private final Bindings bindings = mock(Bindings.class);
+
+  @Test
+  public void shouldRejectOversizedDynamicScript() {
+    String oversized = repeat('x', 1_000_001);
+    DynamicExecutableScript script = dynamicScript(oversized);
+
+    assertThatThrownBy(() -> script.execute(engine, variableScope, bindings))
+        .isInstanceOf(ScriptEvaluationException.class)
+        .hasMessageContaining("exceeds the maximum allowed");
+  }
+
+  @Test
+  public void shouldRejectNullByteInDynamicScript() {
+    DynamicExecutableScript script = dynamicScript("print('safe')\0print('unsafe')");
+
+    assertThatThrownBy(() -> script.execute(engine, variableScope, bindings))
+        .isInstanceOf(ScriptEvaluationException.class)
+        .hasMessageContaining("illegal null bytes");
+  }
+
+  @Test
+  public void shouldRejectNullDynamicScript() {
+    DynamicExecutableScript script = dynamicScript(null);
+
+    assertThatThrownBy(() -> script.execute(engine, variableScope, bindings))
+        .isInstanceOf(ScriptEvaluationException.class)
+        .hasMessageContaining("must not be null");
+  }
+
+  @Test
+  public void shouldRejectNullByteInSourceScriptBeforeCompilation() {
+    SourceExecutableScript script = new SourceExecutableScript("javascript", "print('safe')\0print('unsafe')");
+
+    assertThatThrownBy(() -> script.execute(engine, variableScope, bindings))
+        .isInstanceOf(ScriptEvaluationException.class)
+        .hasMessageContaining("illegal null bytes");
+  }
+
+  private DynamicExecutableScript dynamicScript(final String source) {
+    return new DynamicExecutableScript(mock(Expression.class), "javascript") {
+      @Override
+      public String getScriptSource(VariableScope scope) {
+        return source;
+      }
+    };
+  }
+
+  private static String repeat(char value, int count) {
+    StringBuilder result = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      result.append(value);
+    }
+    return result.toString();
+  }
+}

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/util/ReflectUtilSecurityTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/util/ReflectUtilSecurityTest.java
@@ -1,0 +1,37 @@
+package org.finos.fluxnova.bpm.engine.impl.util;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.finos.fluxnova.bpm.engine.ProcessEngineException;
+import org.junit.Test;
+
+public class ReflectUtilSecurityTest {
+
+  @Test
+  public void shouldRejectSingleDotPathSegment() {
+    assertThatThrownBy(() -> ReflectUtil.validateResourceName("config/./engine.xml"))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("path traversal");
+  }
+
+  @Test
+  public void shouldRejectBareDot() {
+    assertThatThrownBy(() -> ReflectUtil.validateResourceName("."))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("path traversal");
+  }
+
+  @Test
+  public void shouldRejectWindowsTraversal() {
+    assertThatThrownBy(() -> ReflectUtil.validateResourceName("config\\..\\secret.xml"))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("path traversal");
+  }
+
+  @Test
+  public void shouldRejectNullResourceName() {
+    assertThatThrownBy(() -> ReflectUtil.validateResourceName(null))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("must not be null");
+  }
+}

--- a/spin/core/src/main/java/org/finos/fluxnova/spin/scripting/SpinScriptEnv.java
+++ b/spin/core/src/main/java/org/finos/fluxnova/spin/scripting/SpinScriptEnv.java
@@ -91,13 +91,13 @@ public class SpinScriptEnv {
   }
 
   protected static String loadScriptEnv(String language, String extension) {
-    String scriptEnvPath = String.format(ENV_PATH_TEMPLATE, language, extension);
-    // Validate the constructed path contains no traversal sequences
-    for (String segment : scriptEnvPath.split("/")) {
-      if ("..".equals(segment)) {
-        throw LOG.noScriptEnvFoundForLanguage(language, scriptEnvPath);
-      }
+    if (language == null || extension == null
+        || language.contains("/") || language.contains("\\") || language.contains("..")
+        || extension.contains("/") || extension.contains("\\") || extension.contains("..")) {
+      throw new IllegalArgumentException(
+          "Path traversal detected in script language or extension.");
     }
+    String scriptEnvPath = String.format(ENV_PATH_TEMPLATE, language, extension);
     InputStream envResource = SpinScriptException.class.getClassLoader().getResourceAsStream(scriptEnvPath);
 
     if(envResource == null) {

--- a/spin/core/src/test/java/org/finos/fluxnova/spin/scripting/SpinScriptEnvSecurityTest.java
+++ b/spin/core/src/test/java/org/finos/fluxnova/spin/scripting/SpinScriptEnvSecurityTest.java
@@ -1,0 +1,29 @@
+package org.finos.fluxnova.spin.scripting;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public class SpinScriptEnvSecurityTest {
+
+  @Test
+  public void shouldRejectTraversalInLanguage() {
+    assertThatThrownBy(() -> SpinScriptEnv.loadScriptEnv("../javascript", "js"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Path traversal detected");
+  }
+
+  @Test
+  public void shouldRejectPathSeparatorInExtension() {
+    assertThatThrownBy(() -> SpinScriptEnv.loadScriptEnv("javascript", "../js"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Path traversal detected");
+  }
+
+  @Test
+  public void shouldRejectNullInput() {
+    assertThatThrownBy(() -> SpinScriptEnv.loadScriptEnv(null, "js"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Path traversal detected");
+  }
+}

--- a/spring-boot-starter/starter-webapp-core/src/main/java/org/finos/fluxnova/bpm/spring/boot/starter/webapp/filter/ResourceLoadingProcessEnginesFilter.java
+++ b/spring-boot-starter/starter-webapp-core/src/main/java/org/finos/fluxnova/bpm/spring/boot/starter/webapp/filter/ResourceLoadingProcessEnginesFilter.java
@@ -60,7 +60,14 @@ public class ResourceLoadingProcessEnginesFilter extends ProcessEnginesFilter im
 
   @Override
   protected String getWebResourceContents(String name) throws IOException {
-    validateResourceName(name);
+    if (name == null) {
+      throw new IOException("Resource name must not be null.");
+    }
+    String normalized = name.replace('\\', '/');
+    if (normalized.contains("../") || normalized.contains("./")
+        || normalized.equals("..") || normalized.equals(".")) {
+      throw new IOException("Path traversal detected in resource name.");
+    }
     InputStream is = null;
 
     try {
@@ -130,15 +137,5 @@ public class ResourceLoadingProcessEnginesFilter extends ProcessEnginesFilter im
     return input;
   }
 
-  private static void validateResourceName(String name) throws IOException {
-    if (name == null) {
-      throw new IOException("Resource name must not be null");
-    }
-    String normalized = name.replace('\\', '/');
-    for (String segment : normalized.split("/")) {
-      if ("..".equals(segment)) {
-        throw new IOException("Resource name contains illegal path traversal sequence: " + name);
-      }
-    }
-  }
+
 }

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/finos/fluxnova/bpm/spring/boot/starter/webapp/filter/ResourceLoadingProcessEnginesFilterSecurityTest.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/finos/fluxnova/bpm/spring/boot/starter/webapp/filter/ResourceLoadingProcessEnginesFilterSecurityTest.java
@@ -1,0 +1,40 @@
+package org.finos.fluxnova.bpm.spring.boot.starter.webapp.filter;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class ResourceLoadingProcessEnginesFilterSecurityTest {
+
+  @Test
+  public void shouldRejectUnixTraversal() {
+    TestFilter filter = new TestFilter();
+    assertThatThrownBy(() -> filter.readResource("../../application.properties"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Path traversal detected");
+  }
+
+  @Test
+  public void shouldRejectWindowsTraversal() {
+    TestFilter filter = new TestFilter();
+    assertThatThrownBy(() -> filter.readResource("..\\..\\application.properties"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Path traversal detected");
+  }
+
+  @Test
+  public void shouldRejectNullResourceName() {
+    TestFilter filter = new TestFilter();
+    assertThatThrownBy(() -> filter.readResource(null))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("must not be null");
+  }
+
+  private static class TestFilter extends ResourceLoadingProcessEnginesFilter {
+    String readResource(String name) throws IOException {
+      return getWebResourceContents(name);
+    }
+  }
+}

--- a/webapps/assembly/src/main/java/org/finos/fluxnova/bpm/webapp/impl/filter/AbstractTemplateFilter.java
+++ b/webapps/assembly/src/main/java/org/finos/fluxnova/bpm/webapp/impl/filter/AbstractTemplateFilter.java
@@ -79,7 +79,12 @@ public abstract class AbstractTemplateFilter implements Filter {
    * @return
    */
   protected boolean hasWebResource(String name) {
-    if (containsPathTraversal(name)) {
+    if (name == null) {
+      return false;
+    }
+    String normalized = name.replace('\\', '/');
+    if (normalized.contains("../") || normalized.contains("./")
+        || normalized.equals("..") || normalized.equals(".")) {
       return false;
     }
     try {
@@ -102,8 +107,13 @@ public abstract class AbstractTemplateFilter implements Filter {
    * @throws IOException
    */
   protected String getWebResourceContents(String name) throws IOException {
-    if (containsPathTraversal(name)) {
-      throw new IOException("Resource name contains illegal path traversal sequence: " + name);
+    if (name == null) {
+      throw new IOException("Resource name must not be null.");
+    }
+    String normalized = name.replace('\\', '/');
+    if (normalized.contains("../") || normalized.contains("./")
+        || normalized.equals("..") || normalized.equals(".")) {
+      throw new IOException("Path traversal detected in resource name.");
     }
 
     InputStream is = null;
@@ -129,20 +139,5 @@ public abstract class AbstractTemplateFilter implements Filter {
     }
   }
 
-  /**
-   * Returns true if the given resource name contains path traversal sequences (CWE-73 fix).
-   * Handles both forward slash and backslash variants.
-   */
-  private boolean containsPathTraversal(String name) {
-    if (name == null) {
-      return true;
-    }
-    String normalized = name.replace('\\', '/');
-    for (String segment : normalized.split("/")) {
-      if ("..".equals(segment)) {
-        return true;
-      }
-    }
-    return false;
-  }
+
 }

--- a/webapps/assembly/src/main/java/org/finos/fluxnova/bpm/webapp/plugin/resource/AbstractAppPluginRootResource.java
+++ b/webapps/assembly/src/main/java/org/finos/fluxnova/bpm/webapp/plugin/resource/AbstractAppPluginRootResource.java
@@ -216,32 +216,32 @@ public class AbstractAppPluginRootResource<T extends AppPlugin> {
   }
 
   protected InputStream getWebResourceAsStream(String assetDirectory, String fileName) {
-      validateResourcePath(assetDirectory, "assetDirectory");
-      validateResourcePath(fileName, "fileName");
-      String resourceName = "/%s/%s".formatted(assetDirectory, fileName);
+    validatePathSegment(assetDirectory);
+    validatePathSegment(fileName);
+    String resourceName = "/%s/%s".formatted(assetDirectory, fileName);
 
     return servletContext.getResourceAsStream(resourceName);
   }
 
   protected InputStream getClasspathResourceAsStream(AppPlugin plugin, String assetDirectory, String fileName) {
-      validateResourcePath(assetDirectory, "assetDirectory");
-      validateResourcePath(fileName, "fileName");
-      String resourceName = "%s/%s".formatted(assetDirectory, fileName);
+    validatePathSegment(assetDirectory);
+    validatePathSegment(fileName);
+    String resourceName = "%s/%s".formatted(assetDirectory, fileName);
     return plugin.getClass().getClassLoader().getResourceAsStream(resourceName);
   }
 
-    private static void validateResourcePath(String value, String label) {
-        if (value == null) {
-            throw new WebApplicationException(Response.status(Status.BAD_REQUEST)
-                    .entity("Invalid " + label + ": must not be null").build());
-        }
-        String normalized = value.replace('\\', '/');
-        for (String segment : normalized.split("/")) {
-            if ("..".equals(segment)) {
-                throw new WebApplicationException(Response.status(Status.BAD_REQUEST)
-                        .entity("Invalid " + label + ": path traversal detected").build());
-            }
-        }
+  /**
+   * Validates that a path segment does not contain directory traversal sequences.
+   */
+  private void validatePathSegment(String segment) {
+    if (segment == null) {
+      throw new RestException(Status.BAD_REQUEST, "Path segment must not be null.");
     }
+    String normalized = segment.replace('\\', '/');
+    if (normalized.contains("../") || normalized.contains("./")
+        || normalized.equals("..") || normalized.equals(".")) {
+      throw new RestException(Status.FORBIDDEN, "Path traversal detected in resource path.");
+    }
+  }
 
 }

--- a/webapps/assembly/src/test/java/org/finos/fluxnova/bpm/webapp/impl/filter/AbstractTemplateFilterSecurityTest.java
+++ b/webapps/assembly/src/test/java/org/finos/fluxnova/bpm/webapp/impl/filter/AbstractTemplateFilterSecurityTest.java
@@ -1,0 +1,72 @@
+package org.finos.fluxnova.bpm.webapp.impl.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AbstractTemplateFilterSecurityTest {
+
+  private TestFilter filter;
+
+  @Before
+  public void setUp() throws ServletException {
+    FilterConfig filterConfig = mock(FilterConfig.class);
+    ServletContext servletContext = mock(ServletContext.class);
+    org.mockito.Mockito.when(filterConfig.getServletContext()).thenReturn(servletContext);
+
+    filter = new TestFilter();
+    filter.init(filterConfig);
+  }
+
+  @Test
+  public void shouldRejectTraversalWhenCheckingResourceExistence() {
+    assertThat(filter.hasResource("../../WEB-INF/web.xml")).isFalse();
+    assertThat(filter.hasResource("..\\..\\WEB-INF\\web.xml")).isFalse();
+  }
+
+  @Test
+  public void shouldRejectNullWhenCheckingResourceExistence() {
+    assertThat(filter.hasResource(null)).isFalse();
+  }
+
+  @Test
+  public void shouldRejectTraversalWhenReadingResource() {
+    assertThatThrownBy(() -> filter.readResource("../WEB-INF/web.xml"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Path traversal detected");
+  }
+
+  @Test
+  public void shouldRejectNullWhenReadingResource() {
+    assertThatThrownBy(() -> filter.readResource(null))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("must not be null");
+  }
+
+  private static class TestFilter extends AbstractTemplateFilter {
+    @Override
+    protected void applyFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) {
+      // no-op
+    }
+
+    boolean hasResource(String name) {
+      return hasWebResource(name);
+    }
+
+    String readResource(String name) throws IOException {
+      return getWebResourceContents(name);
+    }
+  }
+}

--- a/webapps/assembly/src/test/java/org/finos/fluxnova/bpm/webapp/plugin/resource/AbstractAppPluginRootResourceSecurityTest.java
+++ b/webapps/assembly/src/test/java/org/finos/fluxnova/bpm/webapp/plugin/resource/AbstractAppPluginRootResourceSecurityTest.java
@@ -1,0 +1,69 @@
+package org.finos.fluxnova.bpm.webapp.plugin.resource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import javax.servlet.ServletContext;
+
+import org.finos.fluxnova.bpm.engine.rest.exception.RestException;
+import org.finos.fluxnova.bpm.webapp.AppRuntimeDelegate;
+import org.finos.fluxnova.bpm.webapp.plugin.spi.AppPlugin;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AbstractAppPluginRootResourceSecurityTest {
+
+  private TestResource resource;
+  private ServletContext servletContext;
+  private AppPlugin plugin;
+
+  @Before
+  public void setUp() {
+    resource = new TestResource(mock(AppRuntimeDelegate.class));
+    servletContext = mock(ServletContext.class);
+    plugin = mock(AppPlugin.class);
+    resource.servletContext = servletContext;
+  }
+
+  @Test
+  public void shouldAllowNormalWebResourcePath() {
+    resource.webResource("app", "plugin.js");
+    verify(servletContext).getResourceAsStream("/app/plugin.js");
+  }
+
+  @Test
+  public void shouldRejectUnixTraversalInAssetDirectory() {
+    assertThatThrownBy(() -> resource.webResource("../WEB-INF", "web.xml"))
+        .isInstanceOf(RestException.class)
+        .hasMessageContaining("Path traversal detected");
+  }
+
+  @Test
+  public void shouldRejectWindowsTraversalInFileName() {
+    assertThatThrownBy(() -> resource.classpathResource(plugin, "app", "..\\secret.txt"))
+        .isInstanceOf(RestException.class)
+        .hasMessageContaining("Path traversal detected");
+  }
+
+  @Test
+  public void shouldRejectNullPathSegment() {
+    assertThatThrownBy(() -> resource.webResource(null, "plugin.js"))
+        .isInstanceOf(RestException.class)
+        .hasMessageContaining("must not be null");
+  }
+
+  private static class TestResource extends AbstractAppPluginRootResource<AppPlugin> {
+    TestResource(AppRuntimeDelegate<AppPlugin> runtimeDelegate) {
+      super("test", runtimeDelegate);
+    }
+
+    void webResource(String directory, String file) {
+      getWebResourceAsStream(directory, file);
+    }
+
+    void classpathResource(AppPlugin plugin, String directory, String file) {
+      getClasspathResourceAsStream(plugin, directory, file);
+    }
+  }
+}


### PR DESCRIPTION
## Note

This PR has been superseded by #255, which rebuilds the requested Veracode remediations directly on top of the `hotfix/v2.0.3` release line.

The replacement implementation has been reviewed by the contributing organization and reflects the agreed remediation direction.

Closing this PR in favor of #255.

## Summary

This pull request adapts a security remediation to the `2.0.x` release line to address Veracode findings reported against the `v2.0.3` release.

The original remediation was prepared against the `main` development branch. Since `main` has continued to evolve toward the upcoming `3.0` release, the changes in this pull request have been adapted to the current `2.0.x` maintenance codebase while preserving the intended remediation.

## Changes

This pull request includes:
  - Path validation improvements for the affected resource-loading classes.- Script validation improvements for `DynamicExecutableScript` and `SourceExecutableScript`.
  - Log-parameter sanitization to address log-forging concerns while preserving newline and tab characters intentionally present in fixed log-message templates.
  - Focused unit tests covering the new security validation behavior.

## Validation

The adapted implementation was validated by:
  - Building and testing the affected modules.
  - Executing the newly added security-focused unit tests.
  - Successfully completing a full platform build, including all unit tests.
  - Running an additional, local Spring Boot application against the updated artifacts and exercising a representative set of BPMN and DMN models to check for regressions.
  - Verifying that intentional multiline deployment logging remained intact after refining the log-sanitization implementation.

## Notes

This pull request targets the `hotfix/v2.0.3` maintenance branch because the reported Veracode findings apply to the `2.0.x` release line.