### PR TITLE
Release workflow fix for v3.0

### DIFF
--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -22,6 +22,7 @@
       <dependency>
         <groupId>org.jboss.spec.javax.ws.rs</groupId>
         <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+        <version>${version.jaxrs.api}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.platform</groupId>


### PR DESCRIPTION
Fix the release workflow for below error:

Deployment b0c6d4ee-38a6-4aa4-bb23-84d574131f95 failed
[INFO] pkg:maven/org.finos.fluxnova.bpm/fluxnova-engine-rest-core-jakarta@3.0.0:
[INFO] - Dependency management dependency version information is missing for dependency: org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec

Fix for issue : https://github.com/finos/fluxnova-bpm-platform/issues/257