### PR TITLE
Changes from hotfix 2.0.4 - Implement Veracode Security Remediations

### DIFF
--- a/engine/src/main/java/org/finos/fluxnova/bpm/container/impl/deployment/DeployProcessArchiveStep.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/container/impl/deployment/DeployProcessArchiveStep.java
@@ -89,12 +89,12 @@ public class DeployProcessArchiveStep extends DeploymentOperationStep {
     // add all processes listed in the processes.xml
     List<String> listedProcessResources = processArchive.getProcessResourceNames();
     for (String processResource : listedProcessResources) {
-      ReflectUtil.validateResourceName(processResource);
+      String safeResource = ReflectUtil.validateResourceName(processResource);
       InputStream resourceAsStream = null;
       try {
-        resourceAsStream = processApplicationClassloader.getResourceAsStream(processResource);
-        byte[] bytes = IoUtil.readInputStream(resourceAsStream, processResource);
-        deploymentMap.put(processResource, bytes);
+        resourceAsStream = processApplicationClassloader.getResourceAsStream(safeResource);
+        byte[] bytes = IoUtil.readInputStream(resourceAsStream, safeResource);
+        deploymentMap.put(safeResource, bytes);
       } finally {
         IoUtil.closeSilently(resourceAsStream);
       }

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/DynamicExecutableScript.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/DynamicExecutableScript.java
@@ -46,11 +46,12 @@ public abstract class DynamicExecutableScript extends ExecutableScript {
     }
     source = preprocessScript(source, variableScope);
     try {
-        return ScriptEvaluationUtil.evaluate(scriptEngine, source, bindings);
+      return ScriptEvaluationUtil.evaluate(scriptEngine, source, bindings);
     }
     catch (ScriptException e) {
       String activityIdMessage = getActivityIdExceptionMessage(variableScope);
-      throw new ScriptEvaluationException("Unable to evaluate script" + activityIdMessage + ": " + e.getMessage(), e);
+      throw new ScriptEvaluationException(
+          "Unable to evaluate script" + activityIdMessage + ": " + e.getMessage(), e);
     }
   }
 

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/ScriptEvaluationUtil.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/ScriptEvaluationUtil.java
@@ -1,4 +1,3 @@
-
 package org.finos.fluxnova.bpm.engine.impl.scripting;
 
 import java.io.StringReader;
@@ -7,21 +6,37 @@ import javax.script.Bindings;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
+import org.finos.fluxnova.bpm.engine.ScriptEvaluationException;
+
 /**
  * Shared script evaluation helpers.
  */
 final class ScriptEvaluationUtil {
 
-    private ScriptEvaluationUtil() {
-        // utility class
+  static final int MAX_SCRIPT_SOURCE_LENGTH = 500_000;
+
+  private ScriptEvaluationUtil() {
+    // utility class
+  }
+
+  static void validateScriptSource(String scriptSource) {
+    if (scriptSource == null) {
+      throw new ScriptEvaluationException("Script source must not be null");
     }
 
-    static Object evaluate(ScriptEngine scriptEngine, String scriptSource, Bindings bindings) throws ScriptException {
-        if (scriptSource == null) {
-            throw new ScriptException("Script source is null");
-        }
-
-        // Evaluate script source via a reader to avoid direct String eval sinks.
-        return scriptEngine.eval(new StringReader(scriptSource), bindings);
+    if (scriptSource.length() > MAX_SCRIPT_SOURCE_LENGTH) {
+      throw new ScriptEvaluationException(
+          "Script source length (" + scriptSource.length() + ") exceeds "
+              + "maximum permitted length of " + MAX_SCRIPT_SOURCE_LENGTH);
     }
+  }
+
+  static Object evaluate(
+      ScriptEngine scriptEngine,
+      String scriptSource,
+      Bindings bindings) throws ScriptException {
+
+    validateScriptSource(scriptSource);
+    return scriptEngine.eval(new StringReader(scriptSource), bindings);
+  }
 }

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/SourceExecutableScript.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/scripting/SourceExecutableScript.java
@@ -166,6 +166,7 @@ public class SourceExecutableScript extends CompiledExecutableScript {
    *          the new script source code
    */
   public synchronized void setScriptSource(String scriptSource) {
+   ScriptEvaluationUtil.validateScriptSource(scriptSource);
     invalidateCompiledScript();
     this.scriptSource = scriptSource;
   }

--- a/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/util/ReflectUtil.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/engine/impl/util/ReflectUtil.java
@@ -23,6 +23,8 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -121,65 +123,72 @@ public abstract class ReflectUtil {
     }
   }
 
-    /**
-     * Validates that a resource name does not contain path traversal sequences (CWE-73 fix).
-     * Throws ProcessEngineException if the name is null or contains '..' segments.
-     */
-    public static void validateResourceName(String name) {
-        if (name == null) {
-            throw new ProcessEngineException("Resource name must not be null");
-        }
-        // Normalize separators and check for path traversal sequences
-        String normalized = name.replace('\\', '/');
-        for (String segment : normalized.split("/")) {
-            if ("..".equals(segment)) {
-                throw new ProcessEngineException(
-                        "Resource name contains illegal path traversal sequence: " + name);
-            }
-        }
+  public static String validateResourceName(String name) {
+    if (name == null) {
+      throw new ProcessEngineException("Resource name must not be null");
     }
 
+    String decoded;
+    try {
+      decoded = URLDecoder.decode(name, StandardCharsets.UTF_8);
+    }
+    catch (IllegalArgumentException e) {
+      throw new ProcessEngineException(
+          "Resource name contains malformed encoding: " + name);
+    }
+
+    String normalized = decoded.replace('\\', '/');
+    for (String segment : normalized.split("/", -1)) {
+      if ("..".equals(segment)) {
+        throw new ProcessEngineException(
+            "Resource name contains illegal path traversal sequence: " + name);
+      }
+    }
+
+    return normalized;
+  }
+
   public static InputStream getResourceAsStream(String name) {
-    validateResourceName(name);
+    String safeName = validateResourceName(name);
     InputStream resourceStream = null;
     ClassLoader classLoader = getCustomClassLoader();
     if(classLoader != null) {
-      resourceStream = classLoader.getResourceAsStream(name);
+      resourceStream = classLoader.getResourceAsStream(safeName);
     }
 
     if(resourceStream == null) {
       // Try the current Thread context classloader
       classLoader = Thread.currentThread().getContextClassLoader();
-      resourceStream = classLoader.getResourceAsStream(name);
+      resourceStream = classLoader.getResourceAsStream(safeName);
       if(resourceStream == null) {
         // Finally, try the classloader for this class
         classLoader = ReflectUtil.class.getClassLoader();
-        resourceStream = classLoader.getResourceAsStream(name);
+        resourceStream = classLoader.getResourceAsStream(safeName);
       }
     }
     return resourceStream;
-   }
+  }
 
-   public static URL getResource(String name) {
-     validateResourceName(name);
-     URL url = null;
-     ClassLoader classLoader = getCustomClassLoader();
-     if(classLoader != null) {
-       url = classLoader.getResource(name);
-     }
-     if(url == null) {
-       // Try the current Thread context classloader
-       classLoader = Thread.currentThread().getContextClassLoader();
-       url = classLoader.getResource(name);
-       if(url == null) {
-         // Finally, try the classloader for this class
-         classLoader = ReflectUtil.class.getClassLoader();
-         url = classLoader.getResource(name);
-       }
-     }
-
-     return url;
+  public static URL getResource(String name) {
+    String safeName = validateResourceName(name);
+    URL url = null;
+    ClassLoader classLoader = getCustomClassLoader();
+    if(classLoader != null) {
+      url = classLoader.getResource(safeName);
     }
+    if(url == null) {
+      // Try the current Thread context classloader
+      classLoader = Thread.currentThread().getContextClassLoader();
+      url = classLoader.getResource(safeName);
+      if(url == null) {
+        // Finally, try the classloader for this class
+        classLoader = ReflectUtil.class.getClassLoader();
+        url = classLoader.getResource(safeName);
+      }
+    }
+
+    return url;
+  }
 
    public static String getResourceUrlAsString(String name) {
      String url = getResource(name).toString();

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/scripting/DynamicExecutableScriptValidationTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/scripting/DynamicExecutableScriptValidationTest.java
@@ -1,0 +1,72 @@
+package org.finos.fluxnova.bpm.engine.impl.scripting;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.io.Reader;
+
+import javax.script.Bindings;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+import org.finos.fluxnova.bpm.engine.ScriptEvaluationException;
+import org.finos.fluxnova.bpm.engine.delegate.VariableScope;
+import org.junit.jupiter.api.Test;
+
+public class DynamicExecutableScriptValidationTest {
+
+  @Test
+  public void shouldRejectNullSourceBeforeEvaluation() throws ScriptException {
+    ScriptEngine engine = mock(ScriptEngine.class);
+    Bindings bindings = mock(Bindings.class);
+    DynamicExecutableScript script = new TestDynamicExecutableScript(null);
+
+    assertThatThrownBy(() -> script.evaluate(engine, null, bindings))
+        .isInstanceOf(ScriptEvaluationException.class)
+        .hasMessage("Script source must not be null");
+
+    verify(engine, never()).eval(any(Reader.class), any(Bindings.class));
+  }
+
+  @Test
+  public void shouldRejectOversizedSourceBeforeEvaluation() throws ScriptException {
+    ScriptEngine engine = mock(ScriptEngine.class);
+    Bindings bindings = mock(Bindings.class);
+
+    String source =
+        repeat('x', ScriptEvaluationUtil.MAX_SCRIPT_SOURCE_LENGTH + 1);
+
+    DynamicExecutableScript script =
+        new TestDynamicExecutableScript(source);
+
+    assertThatThrownBy(() -> script.evaluate(engine, null, bindings))
+        .isInstanceOf(ScriptEvaluationException.class)
+        .hasMessageContaining("exceeds maximum permitted length");
+
+    verify(engine, never()).eval(any(Reader.class), any(Bindings.class));
+  }
+
+  private static String repeat(char character, int count) {
+    char[] characters = new char[count];
+    java.util.Arrays.fill(characters, character);
+    return new String(characters);
+  }
+
+  private static class TestDynamicExecutableScript extends DynamicExecutableScript {
+
+    private final String source;
+
+    TestDynamicExecutableScript(String source) {
+      super(null, "javascript");
+      this.source = source;
+    }
+
+    @Override
+    public String getScriptSource(VariableScope variableScope) {
+      return source;
+    }
+  }
+}

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/scripting/ScriptEvaluationUtilTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/scripting/ScriptEvaluationUtilTest.java
@@ -1,0 +1,62 @@
+package org.finos.fluxnova.bpm.engine.impl.scripting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.Reader;
+
+import javax.script.Bindings;
+import javax.script.ScriptEngine;
+
+import org.finos.fluxnova.bpm.engine.ScriptEvaluationException;
+import org.junit.jupiter.api.Test;
+
+public class ScriptEvaluationUtilTest {
+
+  @Test
+  public void shouldRejectNullScriptSource() {
+    assertThatThrownBy(() -> ScriptEvaluationUtil.validateScriptSource(null))
+        .isInstanceOf(ScriptEvaluationException.class)
+        .hasMessage("Script source must not be null");
+  }
+
+  @Test
+  public void shouldRejectScriptSourceAboveMaximumLength() {
+    String source = repeat('x', ScriptEvaluationUtil.MAX_SCRIPT_SOURCE_LENGTH + 1);
+
+    assertThatThrownBy(() -> ScriptEvaluationUtil.validateScriptSource(source))
+        .isInstanceOf(ScriptEvaluationException.class)
+        .hasMessageContaining("exceeds maximum permitted length");
+  }
+
+  @Test
+  public void shouldAcceptScriptSourceAtMaximumLength() {
+    String source = repeat('x', ScriptEvaluationUtil.MAX_SCRIPT_SOURCE_LENGTH);
+
+    ScriptEvaluationUtil.validateScriptSource(source);
+  }
+
+  @Test
+  public void shouldEvaluateUsingReaderOverload() throws Exception {
+    ScriptEngine engine = mock(ScriptEngine.class);
+    Bindings bindings = mock(Bindings.class);
+    Object expected = new Object();
+    when(engine.eval(any(Reader.class), org.mockito.ArgumentMatchers.eq(bindings)))
+        .thenReturn(expected);
+
+    Object actual = ScriptEvaluationUtil.evaluate(engine, "1 + 1", bindings);
+
+    assertThat(actual).isSameAs(expected);
+    verify(engine).eval(any(Reader.class), org.mockito.ArgumentMatchers.eq(bindings));
+  }
+
+  private static String repeat(char character, int count) {
+    char[] characters = new char[count];
+    java.util.Arrays.fill(characters, character);
+    return new String(characters);
+  }
+}

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/scripting/SourceExecutableScriptValidationTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/scripting/SourceExecutableScriptValidationTest.java
@@ -1,0 +1,66 @@
+package org.finos.fluxnova.bpm.engine.impl.scripting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import javax.script.CompiledScript;
+
+import org.finos.fluxnova.bpm.engine.ScriptEvaluationException;
+import org.junit.jupiter.api.Test;
+
+public class SourceExecutableScriptValidationTest {
+
+  @Test
+  public void shouldRejectNullReplacementWithoutChangingState() {
+    SourceExecutableScript script = initializedScript();
+    CompiledScript compiledScript = script.compiledScript;
+
+    assertThatThrownBy(() -> script.setScriptSource(null))
+        .isInstanceOf(ScriptEvaluationException.class)
+        .hasMessage("Script source must not be null");
+
+    assertThat(script.getScriptSource()).isEqualTo("original");
+    assertThat(script.compiledScript).isSameAs(compiledScript);
+    assertThat(script.isShouldBeCompiled()).isFalse();
+  }
+
+  @Test
+  public void shouldRejectOversizedReplacementWithoutChangingState() {
+    SourceExecutableScript script = initializedScript();
+    CompiledScript compiledScript = script.compiledScript;
+    String source = repeat('x', ScriptEvaluationUtil.MAX_SCRIPT_SOURCE_LENGTH + 1);
+
+    assertThatThrownBy(() -> script.setScriptSource(source))
+        .isInstanceOf(ScriptEvaluationException.class)
+        .hasMessageContaining("exceeds maximum permitted length");
+
+    assertThat(script.getScriptSource()).isEqualTo("original");
+    assertThat(script.compiledScript).isSameAs(compiledScript);
+    assertThat(script.isShouldBeCompiled()).isFalse();
+  }
+
+  @Test
+  public void shouldAcceptValidReplacementAndInvalidateCompilation() {
+    SourceExecutableScript script = initializedScript();
+
+    script.setScriptSource("replacement");
+
+    assertThat(script.getScriptSource()).isEqualTo("replacement");
+    assertThat(script.compiledScript).isNull();
+    assertThat(script.isShouldBeCompiled()).isTrue();
+  }
+
+  private static SourceExecutableScript initializedScript() {
+    SourceExecutableScript script = new SourceExecutableScript("javascript", "original");
+    script.compiledScript = mock(CompiledScript.class);
+    script.shouldBeCompiled = false;
+    return script;
+  }
+
+  private static String repeat(char character, int count) {
+    char[] characters = new char[count];
+    java.util.Arrays.fill(characters, character);
+    return new String(characters);
+  }
+}

--- a/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/util/ReflectUtilResourceNameTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/engine/impl/util/ReflectUtilResourceNameTest.java
@@ -1,0 +1,51 @@
+package org.finos.fluxnova.bpm.engine.impl.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.finos.fluxnova.bpm.engine.ProcessEngineException;
+import org.junit.jupiter.api.Test;
+
+public class ReflectUtilResourceNameTest {
+
+  @Test
+  public void shouldDecodeAndNormalizeResourceName() {
+    assertThat(ReflectUtil.validateResourceName("folder%2Fsubfolder\\file.txt"))
+        .isEqualTo("folder/subfolder/file.txt");
+  }
+
+  @Test
+  public void shouldRejectNullResourceName() {
+    assertThatThrownBy(() -> ReflectUtil.validateResourceName(null))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessage("Resource name must not be null");
+  }
+
+  @Test
+  public void shouldRejectMalformedEncoding() {
+    assertThatThrownBy(() -> ReflectUtil.validateResourceName("folder/%ZZ/file.txt"))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("malformed encoding");
+  }
+
+  @Test
+  public void shouldRejectLiteralTraversalSegment() {
+    assertThatThrownBy(() -> ReflectUtil.validateResourceName("folder/../file.txt"))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("path traversal sequence");
+  }
+
+  @Test
+  public void shouldRejectEncodedTraversalSegment() {
+    assertThatThrownBy(() -> ReflectUtil.validateResourceName("folder/%2e%2e/file.txt"))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("path traversal sequence");
+  }
+
+  @Test
+  public void shouldRejectBackslashTraversalSegment() {
+    assertThatThrownBy(() -> ReflectUtil.validateResourceName("folder\\..\\file.txt"))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("path traversal sequence");
+  }
+}

--- a/spin/core/src/main/java/org/finos/fluxnova/spin/scripting/SpinScriptEnv.java
+++ b/spin/core/src/main/java/org/finos/fluxnova/spin/scripting/SpinScriptEnv.java
@@ -24,6 +24,8 @@ import org.finos.fluxnova.spin.impl.util.SpinIoUtil;
 import javax.script.ScriptEngine;
 
 import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -92,13 +94,24 @@ public class SpinScriptEnv {
 
   protected static String loadScriptEnv(String language, String extension) {
     String scriptEnvPath = String.format(ENV_PATH_TEMPLATE, language, extension);
-    // Validate the constructed path contains no traversal sequences
-    for (String segment : scriptEnvPath.split("/")) {
+
+    String decoded;
+    try {
+      decoded = URLDecoder.decode(scriptEnvPath, StandardCharsets.UTF_8);
+    }
+    catch (IllegalArgumentException e) {
+      throw LOG.noScriptEnvFoundForLanguage(language, scriptEnvPath);
+    }
+
+    String safePath = decoded.replace('\\', '/');
+    for (String segment : safePath.split("/", -1)) {
       if ("..".equals(segment)) {
         throw LOG.noScriptEnvFoundForLanguage(language, scriptEnvPath);
       }
     }
-    InputStream envResource = SpinScriptException.class.getClassLoader().getResourceAsStream(scriptEnvPath);
+
+    InputStream envResource = SpinScriptException.class.getClassLoader()
+        .getResourceAsStream(safePath);
 
     if(envResource == null) {
       throw LOG.noScriptEnvFoundForLanguage(language, scriptEnvPath);

--- a/spin/core/src/test/java/org/finos/fluxnova/spin/scripting/SpinScriptEnvPathValidationTest.java
+++ b/spin/core/src/test/java/org/finos/fluxnova/spin/scripting/SpinScriptEnvPathValidationTest.java
@@ -1,0 +1,33 @@
+package org.finos.fluxnova.spin.scripting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.finos.fluxnova.spin.SpinScriptException;
+import org.junit.jupiter.api.Test;
+
+public class SpinScriptEnvPathValidationTest {
+
+  @Test
+  public void shouldLoadKnownScriptEnvironment() {
+    assertThat(SpinScriptEnv.loadScriptEnv("javascript", "js")).isNotEmpty();
+  }
+
+  @Test
+  public void shouldRejectEncodedTraversalSegment() {
+    assertThatThrownBy(() -> SpinScriptEnv.loadScriptEnv("%2e%2e", "js"))
+        .isInstanceOf(SpinScriptException.class);
+  }
+
+  @Test
+  public void shouldRejectBackslashTraversalSegment() {
+    assertThatThrownBy(() -> SpinScriptEnv.loadScriptEnv("..\\ignored", "js"))
+        .isInstanceOf(SpinScriptException.class);
+  }
+
+  @Test
+  public void shouldRejectMalformedEncoding() {
+    assertThatThrownBy(() -> SpinScriptEnv.loadScriptEnv("%ZZ", "js"))
+        .isInstanceOf(SpinScriptException.class);
+  }
+}

--- a/spring-boot-starter/starter-webapp-core/src/main/java/org/finos/fluxnova/bpm/spring/boot/starter/webapp/filter/ResourceLoadingProcessEnginesFilter.java
+++ b/spring-boot-starter/starter-webapp-core/src/main/java/org/finos/fluxnova/bpm/spring/boot/starter/webapp/filter/ResourceLoadingProcessEnginesFilter.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import org.finos.fluxnova.bpm.spring.boot.starter.property.WebappProperty;
 
 import org.finos.fluxnova.bpm.webapp.impl.engine.ProcessEnginesFilter;
@@ -60,11 +62,18 @@ public class ResourceLoadingProcessEnginesFilter extends ProcessEnginesFilter im
 
   @Override
   protected String getWebResourceContents(String name) throws IOException {
-    validateResourceName(name);
-    InputStream is = null;
-
+    String safeName;
     try {
-      Resource resource = resourceLoader.getResource("classpath:"+webappProperty.getWebjarClasspath() + name);
+      safeName = validateResourceName(name);
+    }
+    catch (IllegalArgumentException e) {
+      throw new IOException(e.getMessage());
+    }
+
+    InputStream is = null;
+    try {
+      Resource resource = resourceLoader.getResource(
+          "classpath:" + webappProperty.getWebjarClasspath() + safeName);
       is = resource.getInputStream();
 
       BufferedReader reader = new BufferedReader(new InputStreamReader(is));
@@ -130,15 +139,28 @@ public class ResourceLoadingProcessEnginesFilter extends ProcessEnginesFilter im
     return input;
   }
 
-  private static void validateResourceName(String name) throws IOException {
+  private static String validateResourceName(String name) {
     if (name == null) {
-      throw new IOException("Resource name must not be null");
+      throw new IllegalArgumentException("Resource name must not be null");
     }
-    String normalized = name.replace('\\', '/');
-    for (String segment : normalized.split("/")) {
+
+    String decoded;
+    try {
+      decoded = URLDecoder.decode(name, StandardCharsets.UTF_8);
+    }
+    catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Resource name contains malformed encoding: " + name);
+    }
+
+    String normalized = decoded.replace('\\', '/');
+    for (String segment : normalized.split("/", -1)) {
       if ("..".equals(segment)) {
-        throw new IOException("Resource name contains illegal path traversal sequence: " + name);
+        throw new IllegalArgumentException(
+            "Resource name contains illegal path traversal sequence: " + name);
       }
     }
+
+    return normalized;
   }
 }

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/finos/fluxnova/bpm/spring/boot/starter/webapp/filter/ResourceLoadingProcessEnginesFilterPathTest.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/finos/fluxnova/bpm/spring/boot/starter/webapp/filter/ResourceLoadingProcessEnginesFilterPathTest.java
@@ -1,0 +1,72 @@
+package org.finos.fluxnova.bpm.spring.boot.starter.webapp.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.finos.fluxnova.bpm.spring.boot.starter.property.WebappProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+public class ResourceLoadingProcessEnginesFilterPathTest {
+
+  private ResourceLoader resourceLoader;
+  private WebappProperty webappProperty;
+  private TestFilter filter;
+
+  @BeforeEach
+  public void setUp() {
+    resourceLoader = mock(ResourceLoader.class);
+    webappProperty = mock(WebappProperty.class);
+    when(webappProperty.getWebjarClasspath()).thenReturn("webapp/");
+
+    filter = new TestFilter();
+    filter.setResourceLoader(resourceLoader);
+    filter.setWebappProperty(webappProperty);
+  }
+
+  @Test
+  public void shouldUseDecodedAndNormalizedResourceName() throws Exception {
+    Resource resource = mock(Resource.class);
+    when(resourceLoader.getResource("classpath:webapp/app/config.js")).thenReturn(resource);
+    when(resource.getInputStream()).thenReturn(
+        new ByteArrayInputStream("content".getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(filter.read("app%2Fconfig.js")).isEqualTo("content\n");
+    verify(resourceLoader).getResource("classpath:webapp/app/config.js");
+  }
+
+  @Test
+  public void shouldRejectEncodedTraversalBeforeLookup() {
+    assertThatThrownBy(() -> filter.read("app/%2e%2e/config.js"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("path traversal sequence");
+
+    verify(resourceLoader, never()).getResource(anyString());
+  }
+
+  @Test
+  public void shouldRejectMalformedEncodingBeforeLookup() {
+    assertThatThrownBy(() -> filter.read("app/%ZZ/config.js"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("malformed encoding");
+
+    verify(resourceLoader, never()).getResource(anyString());
+  }
+
+  private static class TestFilter extends ResourceLoadingProcessEnginesFilter {
+    String read(String name) throws IOException {
+      return getWebResourceContents(name);
+    }
+  }
+}

--- a/webapps/assembly/src/main/java/org/finos/fluxnova/bpm/webapp/impl/filter/AbstractTemplateFilter.java
+++ b/webapps/assembly/src/main/java/org/finos/fluxnova/bpm/webapp/impl/filter/AbstractTemplateFilter.java
@@ -23,6 +23,8 @@ import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -79,13 +81,19 @@ public abstract class AbstractTemplateFilter implements Filter {
    * @return
    */
   protected boolean hasWebResource(String name) {
-    if (containsPathTraversal(name)) {
+    String safeName;
+    try {
+      safeName = sanitizeResourcePath(name);
+    }
+    catch (IllegalArgumentException e) {
       return false;
     }
+
     try {
-      URL resource = filterConfig.getServletContext().getResource(name);
+      URL resource = filterConfig.getServletContext().getResource(safeName);
       return resource != null;
-    } catch (MalformedURLException e) {
+    }
+    catch (MalformedURLException e) {
       return false;
     }
   }
@@ -102,14 +110,18 @@ public abstract class AbstractTemplateFilter implements Filter {
    * @throws IOException
    */
   protected String getWebResourceContents(String name) throws IOException {
-    if (containsPathTraversal(name)) {
-      throw new IOException("Resource name contains illegal path traversal sequence: " + name);
+    String safeName;
+    try {
+      safeName = sanitizeResourcePath(name);
+    }
+    catch (IllegalArgumentException e) {
+      throw new IOException(e.getMessage());
     }
 
     InputStream is = null;
 
     try {
-      is = filterConfig.getServletContext().getResourceAsStream(name);
+      is = filterConfig.getServletContext().getResourceAsStream(safeName);
 
       BufferedReader reader = new BufferedReader(new InputStreamReader(is));
 
@@ -129,20 +141,28 @@ public abstract class AbstractTemplateFilter implements Filter {
     }
   }
 
-  /**
-   * Returns true if the given resource name contains path traversal sequences (CWE-73 fix).
-   * Handles both forward slash and backslash variants.
-   */
-  private boolean containsPathTraversal(String name) {
+  private static String sanitizeResourcePath(String name) {
     if (name == null) {
-      return true;
+      throw new IllegalArgumentException("Resource name must not be null");
     }
-    String normalized = name.replace('\\', '/');
-    for (String segment : normalized.split("/")) {
+
+    String decoded;
+    try {
+      decoded = URLDecoder.decode(name, StandardCharsets.UTF_8);
+    }
+    catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Resource name contains malformed encoding: " + name);
+    }
+
+    String normalized = decoded.replace('\\', '/');
+    for (String segment : normalized.split("/", -1)) {
       if ("..".equals(segment)) {
-        return true;
+        throw new IllegalArgumentException(
+            "Resource name contains illegal path traversal sequence: " + name);
       }
     }
-    return false;
+
+    return normalized;
   }
 }

--- a/webapps/assembly/src/main/java/org/finos/fluxnova/bpm/webapp/plugin/resource/AbstractAppPluginRootResource.java
+++ b/webapps/assembly/src/main/java/org/finos/fluxnova/bpm/webapp/plugin/resource/AbstractAppPluginRootResource.java
@@ -21,6 +21,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.ServletContext;
 import jakarta.ws.rs.GET;
@@ -216,32 +218,43 @@ public class AbstractAppPluginRootResource<T extends AppPlugin> {
   }
 
   protected InputStream getWebResourceAsStream(String assetDirectory, String fileName) {
-      validateResourcePath(assetDirectory, "assetDirectory");
-      validateResourcePath(fileName, "fileName");
-      String resourceName = "/%s/%s".formatted(assetDirectory, fileName);
-
+    String safeDir = validateResourcePath(assetDirectory, "assetDirectory");
+    String safeFile = validateResourcePath(fileName, "fileName");
+    String resourceName = "/" + safeDir + "/" + safeFile;
     return servletContext.getResourceAsStream(resourceName);
   }
 
   protected InputStream getClasspathResourceAsStream(AppPlugin plugin, String assetDirectory, String fileName) {
-      validateResourcePath(assetDirectory, "assetDirectory");
-      validateResourcePath(fileName, "fileName");
-      String resourceName = "%s/%s".formatted(assetDirectory, fileName);
+    String safeDir = validateResourcePath(assetDirectory, "assetDirectory");
+    String safeFile = validateResourcePath(fileName, "fileName");
+    String resourceName = safeDir + "/" + safeFile;
     return plugin.getClass().getClassLoader().getResourceAsStream(resourceName);
   }
 
-    private static void validateResourcePath(String value, String label) {
-        if (value == null) {
-            throw new WebApplicationException(Response.status(Status.BAD_REQUEST)
-                    .entity("Invalid " + label + ": must not be null").build());
-        }
-        String normalized = value.replace('\\', '/');
-        for (String segment : normalized.split("/")) {
-            if ("..".equals(segment)) {
-                throw new WebApplicationException(Response.status(Status.BAD_REQUEST)
-                        .entity("Invalid " + label + ": path traversal detected").build());
-            }
-        }
+  private static String validateResourcePath(String value, String label) {
+    if (value == null) {
+      throw new WebApplicationException(Response.status(Status.BAD_REQUEST)
+          .entity("Invalid " + label + ": must not be null").build());
     }
+
+    String decoded;
+    try {
+      decoded = URLDecoder.decode(value, StandardCharsets.UTF_8);
+    }
+    catch (IllegalArgumentException e) {
+      throw new WebApplicationException(Response.status(Status.BAD_REQUEST)
+          .entity("Invalid " + label + ": malformed encoding").build());
+    }
+
+    String normalized = decoded.replace('\\', '/');
+    for (String segment : normalized.split("/", -1)) {
+      if ("..".equals(segment)) {
+        throw new WebApplicationException(Response.status(Status.BAD_REQUEST)
+            .entity("Invalid " + label + ": path traversal detected").build());
+      }
+    }
+
+    return normalized;
+  }
 
 }

--- a/webapps/assembly/src/test/java/org/finos/fluxnova/bpm/webapp/impl/filter/AbstractTemplateFilterPathTest.java
+++ b/webapps/assembly/src/test/java/org/finos/fluxnova/bpm/webapp/impl/filter/AbstractTemplateFilterPathTest.java
@@ -1,0 +1,91 @@
+package org.finos.fluxnova.bpm.webapp.impl.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AbstractTemplateFilterPathTest {
+
+  private ServletContext servletContext;
+  private TestFilter filter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    servletContext = mock(ServletContext.class);
+    FilterConfig filterConfig = mock(FilterConfig.class);
+    when(filterConfig.getServletContext()).thenReturn(servletContext);
+
+    filter = new TestFilter();
+    filter.init(filterConfig);
+  }
+
+  @Test
+  public void shouldUseDecodedResourceNameWhenCheckingExistence() throws Exception {
+    URL resource = new URL("file:/app/index.html");
+    when(servletContext.getResource("/app/index.html")).thenReturn(resource);
+
+    assertThat(filter.exists("/app%2Findex.html")).isTrue();
+    verify(servletContext).getResource("/app/index.html");
+  }
+
+  @Test
+  public void shouldReturnFalseForEncodedTraversal() throws Exception {
+    assertThat(filter.exists("/app/%2e%2e/index.html")).isFalse();
+
+    verify(servletContext, never()).getResource(anyString());
+  }
+
+  @Test
+  public void shouldUseNormalizedResourceNameWhenReading() throws Exception {
+    when(servletContext.getResourceAsStream("/app/index.html")).thenReturn(
+        new ByteArrayInputStream("content".getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(filter.read("/app\\index.html")).isEqualTo("content\n");
+    verify(servletContext).getResourceAsStream("/app/index.html");
+  }
+
+  @Test
+  public void shouldRejectMalformedEncodingBeforeReading() {
+    assertThatThrownBy(() -> filter.read("/app/%ZZ/index.html"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("malformed encoding");
+  }
+
+  private static class TestFilter extends AbstractTemplateFilter {
+
+    boolean exists(String name) {
+      return hasWebResource(name);
+    }
+
+    String read(String name) throws IOException {
+      return getWebResourceContents(name);
+    }
+
+    @Override
+    protected void applyFilter(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain chain) throws IOException, ServletException {
+      // not used
+    }
+  }
+}

--- a/webapps/assembly/src/test/java/org/finos/fluxnova/bpm/webapp/plugin/resource/AbstractAppPluginRootResourcePathTest.java
+++ b/webapps/assembly/src/test/java/org/finos/fluxnova/bpm/webapp/plugin/resource/AbstractAppPluginRootResourcePathTest.java
@@ -1,0 +1,82 @@
+package org.finos.fluxnova.bpm.webapp.plugin.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import jakarta.servlet.ServletContext;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.finos.fluxnova.bpm.webapp.AppRuntimeDelegate;
+import org.finos.fluxnova.bpm.webapp.plugin.spi.AppPlugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class AbstractAppPluginRootResourcePathTest {
+
+  private ServletContext servletContext;
+  private TestResource resource;
+
+  @BeforeEach
+  public void setUp() {
+    servletContext = mock(ServletContext.class);
+    resource = new TestResource(mock(AppRuntimeDelegate.class));
+    resource.servletContext = servletContext;
+  }
+
+  @Test
+  public void shouldUseDecodedAndNormalizedWebResourcePath() {
+    InputStream expected = new ByteArrayInputStream(new byte[0]);
+    when(servletContext.getResourceAsStream("/plugin/assets/app/plugin.js"))
+        .thenReturn(expected);
+
+    InputStream actual = resource.web("plugin%2Fassets", "app\\plugin.js");
+
+    assertThat(actual).isSameAs(expected);
+    verify(servletContext).getResourceAsStream("/plugin/assets/app/plugin.js");
+  }
+
+  @Test
+  public void shouldRejectEncodedTraversalBeforeWebLookup() {
+    assertBadRequest(() -> resource.web("plugin/%2e%2e", "plugin.js"));
+
+    verify(servletContext, never()).getResourceAsStream(anyString());
+  }
+
+  @Test
+  public void shouldRejectMalformedEncodingBeforeWebLookup() {
+    assertBadRequest(() -> resource.web("plugin/%ZZ", "plugin.js"));
+
+    verify(servletContext, never()).getResourceAsStream(anyString());
+  }
+
+  private static void assertBadRequest(Runnable invocation) {
+    try {
+      invocation.run();
+      fail(
+          "Expected WebApplicationException");
+    } catch (WebApplicationException e) {
+      assertThat(e.getResponse().getStatus())
+          .isEqualTo(Status.BAD_REQUEST.getStatusCode());
+    }
+  }
+
+  private static class TestResource extends AbstractAppPluginRootResource<AppPlugin> {
+
+    TestResource(AppRuntimeDelegate<AppPlugin> runtimeDelegate) {
+      super("test", runtimeDelegate);
+    }
+
+    InputStream web(String assetDirectory, String fileName) {
+      return getWebResourceAsStream(assetDirectory, fileName);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements the requested Veracode remediations

## Files Updated

### Path Traversal
- `ReflectUtil`
- `DeployProcessArchiveStep`
- `SpinScriptEnv`
- `ResourceLoadingProcessEnginesFilter`
- `AbstractTemplateFilter`
- `AbstractAppPluginRootResource`    

### Script Evaluation
- `ScriptEvaluationUtil`
- `DynamicExecutableScript`
- `SourceExecutableScript`

## Validation

The implementation has been validated through:
- Successful local builds
- Successful `mvn verify` validation of the affected modules
- Successful full repository `mvn verify`
- Targeted, additional unit tests covering the newly introduced validation logic

In addition, a local Spring Boot application was used during development to help validate the updated implementation and reduce the likelihood of regressions not covered by the platform's included unit tests.