### PR TITLE
remove jackson-datatype-jsr310 dependency from engine-rest modules

### DIFF
--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -92,12 +92,6 @@
       <version>${version.jackson}</version>
     </dependency>
 
-    <dependency>
-      <groupId>tools.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>3.0.0-rc2</version>
-    </dependency>
-
     <!-- provided deps -->
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -96,12 +96,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>tools.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>3.0.0-rc2</version>
-    </dependency>
-
     <!-- Jakarta XML Bind API - needed for Jackson JAXB module -->
     <dependency>
       <groupId>jakarta.xml.bind</groupId>


### PR DESCRIPTION
Closes: https://github.com/finos/fluxnova-bpm-platform/issues/244

Removes the tools.jackson.datatype:jackson-datatype-jsr310:3.0.0-rc2 dependency
from engine-rest and engine-rest-jakarta. The RC is binary-incompatible with
the jackson-databind 3.1.x shipped everywhere else and breaks mappers built
with module discovery (e.g. Spring's HTTP message converters) on java.time
values — see the linked issue for full analysis.