### PR TITLE
Removes unanchored internal and configuration directories from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,3 @@ camunda-h2-dbs
 
 *.DS_Store
 .vscode/
-
-internal
-configuration

--- a/Fluxnova-build-readme.md
+++ b/Fluxnova-build-readme.md
@@ -165,13 +165,14 @@ You can run Fluxnova in two modes: **Tomcat** and **Spring Boot**.
 
 ### Running the Tomcat Version
 
-1. After a successful build, extract the Tomcat distribution archive:
+1. After a successful build, extract the Tomcat distribution archive into a directory **outside** the repository.
+   The archive has no top-level folder — extracting it into the repository root will clutter your `git status` with untracked distribution files. The `-d` target below (`~/fluxnova-tomcat`) is just an example; change it to any location you prefer:
    ```bash
-   unzip distro/tomcat/distro/target/fluxnova-bpm-tomcat-0.0.1-SNAPSHOT.zip
+   unzip distro/tomcat/distro/target/fluxnova-bpm-tomcat-0.0.1-SNAPSHOT.zip -d ~/fluxnova-tomcat
    ```
-2. Navigate to the extracted folder:
+2. Navigate to the extraction directory:
    ```bash
-   cd fluxnova-bpm-tomcat-0.0.1-SNAPSHOT
+   cd ~/fluxnova-tomcat
    ```
 3. Start the Fluxnova Tomcat server:
    ```bash
@@ -181,13 +182,14 @@ You can run Fluxnova in two modes: **Tomcat** and **Spring Boot**.
 
 ### Running the Spring Boot Version
 
-1. After a successful build, extract the Spring Boot distribution archive:
+1. After a successful build, extract the Spring Boot distribution archive into a directory **outside** the repository.
+   The archive has no top-level folder — extracting it into the repository root will clutter your `git status` with untracked distribution files. The `-d` target below (`~/fluxnova-run`) is just an example; change it to any location you prefer:
    ```bash
-   unzip distro/run/distro/target/fluxnova-bpm-run-0.0.1-SNAPSHOT.zip
+   unzip distro/run/distro/target/fluxnova-bpm-run-0.0.1-SNAPSHOT.zip -d ~/fluxnova-run
    ```
-2. Navigate to the extracted folder:
+2. Navigate to the extraction directory:
    ```bash
-   cd fluxnova-bpm-run-0.0.1-SNAPSHOT
+   cd ~/fluxnova-run
    ```
 3. Start the Spring Boot server:
    ```bash

--- a/Fluxnova-getting-started.md
+++ b/Fluxnova-getting-started.md
@@ -33,6 +33,8 @@ For detailed build and run instructions, see the [Fluxnova Build Guide](https://
   mvn clean install
   ```
 - Run Tomcat or Spring Boot version (see build guide for details).
+
+> **Note:** If you download a Fluxnova distribution archive, unzip it **outside** your local clone of this repository. Extracting it into the repository root leaves the distribution files (e.g. `configuration/`, `internal/`, start/shutdown scripts) cluttering your `git status` as untracked files.
 - Alternatively, use the official Docker image:
   ```sh
   docker pull ghcr.io/finos/fluxnova-bpm-platform:1.1.0


### PR DESCRIPTION
Removes the unanchored internal and configuration entries from .gitignore that silently ignored new files in legitimate source directories, and updates the build/getting-started docs to extract distribution archives outside the repository instead.

Closes https://github.com/finos/fluxnova-bpm-platform/issues/251