### PR TITLE
Fix Windows Spring Boot Process Application Resource Scanning in 3.0.0

### DIFF
--- a/engine/src/main/java/org/finos/fluxnova/bpm/container/impl/deployment/scanning/ClassPathProcessApplicationScanner.java
+++ b/engine/src/main/java/org/finos/fluxnova/bpm/container/impl/deployment/scanning/ClassPathProcessApplicationScanner.java
@@ -108,7 +108,7 @@ public class ClassPathProcessApplicationScanner implements ProcessApplicationSca
     if(isPaLocal) {
 
       if (urlPath.startsWith("file:") || urlPath.startsWith("jar:") || urlPath.startsWith("wsjar:") || urlPath.startsWith("zip:")) {
-        urlPath = url.getPath();
+        urlPath = normalizeWindowsPath(url.getPath());
         int withinArchive = urlPath.indexOf('!');
         if (withinArchive != -1) {
           urlPath = urlPath.substring(0, withinArchive);
@@ -120,7 +120,7 @@ public class ClassPathProcessApplicationScanner implements ProcessApplicationSca
 
     } else {
       if (urlPath.startsWith("file:") || urlPath.startsWith("jar:") || urlPath.startsWith("wsjar:") || urlPath.startsWith("zip:")) {
-        urlPath = url.getPath();
+        urlPath = normalizeWindowsPath(url.getPath());
         int withinArchive = urlPath.indexOf('!');
         if (withinArchive != -1) {
           urlPath = urlPath.substring(0, withinArchive);
@@ -140,6 +140,22 @@ public class ClassPathProcessApplicationScanner implements ProcessApplicationSca
 
     scanPath(urlPath, paResourceRootPath, isPaLocal, additionalResourceSuffixes, resourceMap);
 
+  }
+
+  protected String normalizeWindowsPath(String path) {
+    return normalizeWindowsPath(path, File.separatorChar);
+  }
+
+  protected String normalizeWindowsPath(String path, char separatorChar) {
+    if (separatorChar == '\\'
+        && path.length() > 2
+        && path.charAt(0) == '/'
+        && Character.isLetter(path.charAt(1))
+        && path.charAt(2) == ':') {
+      return path.substring(1);
+    }
+
+    return path;
   }
 
   protected void scanPath(String urlPath, String paResourceRootPath, boolean isPaLocal, String[] additionalResourceSuffixes, Map<String, byte[]> resourceMap) {

--- a/engine/src/test/java/org/finos/fluxnova/bpm/container/impl/deployment/scanning/ClassPathProcessApplicationScannerWindowsPathTest.java
+++ b/engine/src/test/java/org/finos/fluxnova/bpm/container/impl/deployment/scanning/ClassPathProcessApplicationScannerWindowsPathTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.finos.fluxnova.bpm.container.impl.deployment.scanning;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests Windows-specific path normalization performed by
+ * {@link ClassPathProcessApplicationScanner}.
+ */
+public class ClassPathProcessApplicationScannerWindowsPathTest {
+
+  protected ClassPathProcessApplicationScanner scanner;
+
+  @Before
+  public void setUp() {
+    scanner = new ClassPathProcessApplicationScanner();
+  }
+
+  @Test
+  public void shouldRemoveLeadingSlashFromWindowsDrivePath() {
+    assertEquals(
+        "C:/dev/fluxnova-loan-review/target/classes/META-INF/processes.xml",
+        scanner.normalizeWindowsPath(
+            "/C:/dev/fluxnova-loan-review/target/classes/META-INF/processes.xml",
+            '\\'));
+  }
+
+  @Test
+  public void shouldSupportLowercaseWindowsDriveLetter() {
+    assertEquals(
+        "c:/dev/fluxnova-loan-review",
+        scanner.normalizeWindowsPath(
+            "/c:/dev/fluxnova-loan-review",
+            '\\'));
+  }
+
+  @Test
+  public void shouldNotChangeWindowsPathWithoutLeadingSlash() {
+    assertEquals(
+        "C:/dev/fluxnova-loan-review",
+        scanner.normalizeWindowsPath(
+            "C:/dev/fluxnova-loan-review",
+            '\\'));
+  }
+
+  @Test
+  public void shouldNotChangeNonDriveWindowsPath() {
+    assertEquals(
+        "/dev/fluxnova-loan-review",
+        scanner.normalizeWindowsPath(
+            "/dev/fluxnova-loan-review",
+            '\\'));
+  }
+
+  @Test
+  public void shouldNotChangePathOnNonWindowsPlatform() {
+    assertEquals(
+        "/C:/dev/fluxnova-loan-review",
+        scanner.normalizeWindowsPath(
+            "/C:/dev/fluxnova-loan-review",
+            '/'));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes Windows Spring Boot process application resource scanning when using `@EnableProcessApplication` with an empty `META-INF/processes.xml`.

Beginning with Fluxnova `2.0.3`, `ClassPathProcessApplicationScanner` can receive a Windows drive-letter path from `URL.getPath()` in the form:

```text
/C:/dev/fluxnova-loan-review/target/classes/META-INF/processes.xml
```

Passing that value directly to Paths.get(String) causes Windows to reject the drive-letter colon with:

```
java.nio.file.InvalidPathException:
Illegal char <:> at index 2
```

## Change

The scanner now normalizes this specific Windows path representation before passing it to `Paths.get(...)`:

`/C:/dev/...  ->  C:/dev/...`

The change is intentionally narrow and preserves the existing resource-scanning and path-normalization behavior for other platforms and resource types.

A focused unit test has also been added to cover Windows drive-letter path normalization without requiring the test suite itself to run on Windows.

## Validation

The fix has been validated against the full Fluxnova test suite using:

`mvn clean install`

The patched scanner has also been successfully tested with a Spring Boot process application on Linux.

Windows validation has been performed against the affected Fluxnova releases using a Spring Boot process application with:

- `@EnableProcessApplication`
- an empty `META-INF/processes.xml`
- automatic BPMN resource discovery

The same process application works correctly without the patch on Fluxnova `2.0.0`, `2.0.1` and `2.0.2`.

Fixes https://github.com/finos/fluxnova-bpm-platform/issues/286 in version `3.0.0`. A separate PR addresses the issue for the `2.0.x` release train.