### PR TITLE
feat: disable FAIL_ON_NULL_FOR_PRIMITIVES in JsonMapper configurations

### DIFF
--- a/clients/java/client/src/it/java/org/finos/fluxnova/bpm/client/rule/EngineRule.java
+++ b/clients/java/client/src/it/java/org/finos/fluxnova/bpm/client/rule/EngineRule.java
@@ -128,6 +128,7 @@ public class EngineRule implements BeforeEachCallback, AfterEachCallback {
       SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
       objectMapper = JsonMapper.builder()
               .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+              .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
               .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
               .defaultDateFormat(dateFormat)
               .build();

--- a/clients/java/client/src/main/java/org/finos/fluxnova/bpm/client/impl/ExternalTaskClientBuilderImpl.java
+++ b/clients/java/client/src/main/java/org/finos/fluxnova/bpm/client/impl/ExternalTaskClientBuilderImpl.java
@@ -270,6 +270,7 @@ public class ExternalTaskClientBuilderImpl implements ExternalTaskClientBuilder 
 
     jsonMapper = JsonMapper.builder()
         .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
         .disable(DeserializationFeature.FAIL_ON_UNRESOLVED_OBJECT_IDS)
         .disable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
         .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -25,10 +25,6 @@
         <version>${version.jaxrs.api}</version>
       </dependency>
       <dependency>
-        <groupId>org.jboss.spec.javax.ws.rs</groupId>
-        <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-      </dependency>
-      <dependency>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakarta.jakartaee-bom</artifactId>
         <version>${version.jakarta-ee-spec}</version>

--- a/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/mapper/JacksonConfigurator.java
+++ b/engine-rest/engine-rest/src/main/java/org/finos/fluxnova/bpm/engine/rest/mapper/JacksonConfigurator.java
@@ -41,6 +41,7 @@ public class JacksonConfigurator implements ContextResolver<ObjectMapper> {
     SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatString);
     return JsonMapper.builder()
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
             .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
             .defaultDateFormat(dateFormat)
             .build();

--- a/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/util/JsonPathUtil.java
+++ b/engine-rest/engine-rest/src/test/java/org/finos/fluxnova/bpm/engine/rest/util/JsonPathUtil.java
@@ -36,6 +36,7 @@ public final class JsonPathUtil {
           SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatString);
           return JsonMapper.builder()
                   .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                  .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
                   .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
                   .defaultDateFormat(dateFormat)
                   .build();

--- a/spin/dataformat-json-jackson/src/main/java/org/finos/fluxnova/spin/impl/json/jackson/format/JacksonJsonDataFormat.java
+++ b/spin/dataformat-json-jackson/src/main/java/org/finos/fluxnova/spin/impl/json/jackson/format/JacksonJsonDataFormat.java
@@ -77,6 +77,7 @@ public class JacksonJsonDataFormat implements DataFormat<SpinJsonNode> {
   public JacksonJsonDataFormat(String name) {
     this(name, JsonMapper.builder()
             .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
             .build());
   }
 


### PR DESCRIPTION
In jackson2, the feature DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES is defaulted to false while it has been changed to true in Jackson3 that causes the failure in null scenario