### PR TITLE
Db contrib/veracode CWE-611 (Improper Restriction of XML External Entity Reference)

### DIFF
--- a/spin/dataformat-xml-dom/src/main/java/org/finos/fluxnova/spin/impl/xml/dom/format/DomXmlDataFormat.java
+++ b/spin/dataformat-xml-dom/src/main/java/org/finos/fluxnova/spin/impl/xml/dom/format/DomXmlDataFormat.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
 import org.finos.fluxnova.spin.impl.xml.dom.DomXmlAttribute;
 import org.finos.fluxnova.spin.impl.xml.dom.DomXmlElement;
@@ -204,7 +205,9 @@ public class DomXmlDataFormat implements DataFormat<SpinXmlElement> {
   }
 
   public static TransformerFactory defaultTransformerFactory() {
-    return TransformerFactory.newInstance();
+    TransformerFactory transformerFactory = TransformerFactory.newInstance();
+    enableSecureProcessing(transformerFactory);
+    return transformerFactory;
   }
 
   public static DocumentBuilderFactory defaultDocumentBuilderFactory() {
@@ -278,6 +281,25 @@ public class DomXmlDataFormat implements DataFormat<SpinXmlElement> {
       dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
       dbf.setAttribute(JAXP_ACCESS_EXTERNAL_SCHEMA, resolveAccessExternalSchemaProperty());
     } catch (ParserConfigurationException | IllegalArgumentException ignored) {
+      // ignored
+    }
+  }
+
+  /*
+   * Configures the TransformerFactory to process XML securely.
+   * Disables external DTD and stylesheet resolution to prevent XXE attacks (CWE-611).
+   * If the implementing transformer does not support one or multiple features,
+   * the failed feature is ignored. The transformer might not be protected,
+   * if the feature assignment fails.
+   *
+   * @param transformerFactory The factory to configure.
+   */
+  protected static void enableSecureProcessing(TransformerFactory transformerFactory) {
+    try {
+      transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+    } catch (TransformerConfigurationException | IllegalArgumentException ignored) {
       // ignored
     }
   }

--- a/spin/dataformat-xml-dom/src/test/java/org/finos/fluxnova/spin/xml/dom/format/spi/DomXmlDataFormatProtectionTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/finos/fluxnova/spin/xml/dom/format/spi/DomXmlDataFormatProtectionTest.java
@@ -18,8 +18,12 @@ package org.finos.fluxnova.spin.xml.dom.format.spi;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.finos.fluxnova.spin.DataFormats;
 import org.finos.fluxnova.spin.impl.xml.dom.format.DomXmlDataFormat;
@@ -68,6 +72,51 @@ public class DomXmlDataFormatProtectionTest {
         .hasMessageContaining("SPIN/DOM-XML-01009 Unable to parse input into DOM document")
         .hasStackTraceContaining("DOCTYPE")
         .hasStackTraceContaining("http://apache.org/xml/features/disallow-doctype-decl");
+  }
+
+  /*
+   * Verifies that the TransformerFactory used by the writer is hardened against CWE-611
+   * (XML External Entity Reference). The test simulates an attacker-controlled XSL
+   * that attempts to include an external stylesheet via xsl:include (file URI).
+   * With ACCESS_EXTERNAL_STYLESHEET set to "" and FEATURE_SECURE_PROCESSING enabled,
+   * the transformer must reject external resource resolution and throw SpinXmlDataFormatException.
+   */
+  @Test
+  public void shouldDenyExternalStylesheetAccessInFormattingConfiguration() throws Exception {
+    // given
+    // A minimal valid XSL file on disk, simulating an external resource an attacker
+    // could reference.
+    Path importedStylesheet = Files.createTempFile("spin-dom-xml-external-", ".xsl");
+    Files.write(
+      importedStylesheet,
+      ("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">"
+        + "<xsl:template match=\"/\">"
+        + "<included/>"
+        + "</xsl:template>"
+        + "</xsl:stylesheet>")
+        .getBytes(StandardCharsets.UTF_8));
+
+    // The security-sensitive line: xsl:include with an external file:// URI.
+    // This is the attack vector that must be blocked by the hardened TransformerFactory.
+    String stylesheetWithExternalIncluded = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      + "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">"
+      + "<xsl:include href=\"" + importedStylesheet.toUri() + "\"/>"
+      + "</xsl:stylesheet>";
+
+    // when / then
+    // Setting this as the formatting configuration triggers template compilation, at which
+    // point the transformer attempts to resolve the external include and must fail.
+    try {
+      assertThatThrownBy(() ->
+        format.setFormattingConfiguration(
+          new ByteArrayInputStream(stylesheetWithExternalIncluded.getBytes(StandardCharsets.UTF_8))))
+        .isInstanceOf(SpinXmlDataFormatException.class)
+        .hasMessageContaining("SPIN/DOM-XML-01038 Failed to get formatting templates")
+        .hasStackTraceContaining("accessExternalStylesheet");
+    } finally {
+      Files.deleteIfExists(importedStylesheet);
+    }
   }
 
 }


### PR DESCRIPTION
## Summary

This PR fixes **CWE-611 (Improper Restriction of XML External Entity Reference)** for XML transformation/writer paths in `spin/dataformat-xml-dom`.

## Code changes

### File: `DomXmlDataFormat.java`

Added `enableSecureProcessing(TransformerFactory)` method to harden transformer configuration.

Hardened `defaultTransformerFactory()` by configuring:

```java
transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
```

This protects both transformation sinks used by `DomXmlDataFormatWriter`:

- Pretty-print path:

  ```java
  getFormattingTransformer().transform(...)
  ```

- Non-pretty-print path:

  ```java
  getTransformer().transform(...)
  ```

## Test changes

### File: `DomXmlDataFormatProtectionTest.java`

Added test:

```java
shouldDenyExternalStylesheetAccessInFormattingConfiguration()
```

The test:

- Creates an XSL that attempts to include an external stylesheet via: xsl:include href="file:..."
- Verifies configuration fails with `SpinXmlDataFormatException`
- Confirms external stylesheet resolution is blocked by secure transformer settings

# Why this fix

Parser-side hardening already existed (`DocumentBuilderFactory`), but the writer-side `TransformerFactory` was not explicitly hardened.

This PR closes that gap and aligns with OWASP/JAXP XXE prevention guidance.

# Validation

The implementation has been validated through:

- ✅ Successful local builds
- ✅ Successful `mvn -pl spin/dataformat-all -am verify` validation of the affected modules
- ✅ Successful full repository `mvn verify`
- ✅ Targeted, additional unit tests covering the newly introduced XXE protection logic

# Impact Assessment

- Security hardening only: XXE/external resource resolution prevention in transformer path
- No functional behavior changes: valid internal XML/XSL processing is unaffected